### PR TITLE
[WIP] handle lists in building input rows fixes #64

### DIFF
--- a/pymapd/_loaders.py
+++ b/pymapd/_loaders.py
@@ -9,7 +9,7 @@ def _build_input_rows(data):
     for row in data:
         input_row = TStringRow()
         input_row.cols = [
-            TStringValue("{"i + ",".join(str(y) for y in x) + "}")
+            TStringValue("{" + ",".join(str(y) for y in x) + "}")
             if type(x) in (list, tuple)
             else TStringValue(str(x)) for x in row
         ]

--- a/pymapd/_loaders.py
+++ b/pymapd/_loaders.py
@@ -3,11 +3,15 @@ Internal helpers for loading data
 """
 from mapd.ttypes import TStringRow, TStringValue
 
-
 def _build_input_rows(data):
     input_data = []
     for row in data:
         input_row = TStringRow()
-        input_row.cols = ["{"+",".join(str(y) for y in x)+"}" if type(x)==list else TStringValue(str(x)) for x in row]
+        input_row.cols = [
+            "{"+",".join(str(y) for y in x)+"}"
+            if type(x) in (list, tuple)
+            else TStringValue(str(x)) for x in row
+        ]
         input_data.append(input_row)
     return input_data
+

--- a/pymapd/_loaders.py
+++ b/pymapd/_loaders.py
@@ -3,6 +3,7 @@ Internal helpers for loading data
 """
 from mapd.ttypes import TStringRow, TStringValue
 import collections
+import six
 
 
 def _build_input_rows(data):
@@ -11,7 +12,8 @@ def _build_input_rows(data):
         input_row = TStringRow()
         input_row.cols = [
             TStringValue("{" + ",".join(str(y) for y in x) + "}")
-            if isinstance(x, collections.Sequence)
+            if isinstance(x, collections.Sequence) and
+            not isinstance(x, six.str_types)
             else TStringValue(str(x)) for x in row
         ]
         input_data.append(input_row)

--- a/pymapd/_loaders.py
+++ b/pymapd/_loaders.py
@@ -13,7 +13,7 @@ def _build_input_rows(data):
         input_row.cols = [
             TStringValue("{" + ",".join(str(y) for y in x) + "}")
             if isinstance(x, collections.Sequence) and
-            not isinstance(x, six.str_types)
+            not isinstance(x, six.string_types)
             else TStringValue(str(x)) for x in row
         ]
         input_data.append(input_row)

--- a/pymapd/_loaders.py
+++ b/pymapd/_loaders.py
@@ -15,4 +15,3 @@ def _build_input_rows(data):
         ]
         input_data.append(input_row)
     return input_data
-

--- a/pymapd/_loaders.py
+++ b/pymapd/_loaders.py
@@ -8,6 +8,6 @@ def _build_input_rows(data):
     input_data = []
     for row in data:
         input_row = TStringRow()
-        input_row.cols = [TStringValue(str(x)) for x in row]
+        input_row.cols = ["{"+",".join(str(y) for y in x)+"}" if type(x)==list else TStringValue(str(x)) for x in row]
         input_data.append(input_row)
     return input_data

--- a/pymapd/_loaders.py
+++ b/pymapd/_loaders.py
@@ -2,6 +2,7 @@
 Internal helpers for loading data
 """
 from mapd.ttypes import TStringRow, TStringValue
+import collections
 
 
 def _build_input_rows(data):
@@ -10,7 +11,7 @@ def _build_input_rows(data):
         input_row = TStringRow()
         input_row.cols = [
             TStringValue("{" + ",".join(str(y) for y in x) + "}")
-            if type(x) in (list, tuple)
+            if isinstance(x, collections.Sequence)
             else TStringValue(str(x)) for x in row
         ]
         input_data.append(input_row)

--- a/pymapd/_loaders.py
+++ b/pymapd/_loaders.py
@@ -9,7 +9,7 @@ def _build_input_rows(data):
     for row in data:
         input_row = TStringRow()
         input_row.cols = [
-            "{"+",".join(str(y) for y in x)+"}"
+            TStringValue("{"i + ",".join(str(y) for y in x) + "}")
             if type(x) in (list, tuple)
             else TStringValue(str(x)) for x in row
         ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ universal=0
 
 [flake8]
 exclude = tests/data,mapd,docs,benchmarks,scripts
+ignore = E741
 
 [tool:pytest]
 addopts = -rsx -v

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,8 +2,7 @@
 universal=0
 
 [flake8]
-exclude = tests/data,mapd,docs,benchmarks,scripts
-ignore = E741
+exclude = tests/data,mapd,docs,benchmarks,scripts,.eggs
 
 [tool:pytest]
 addopts = -rsx -v

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -28,8 +28,8 @@ class TestLoaders(object):
                     TStringRow(cols=[TStringValue(str_val='2', is_null=None),
                                      TStringValue(str_val='b', is_null=None)]),
                     TStringRow(cols=[TStringValue(str_val='3', is_null=None),
-                                     TStringValue(str_val='{c,d,e}', is_null=None)]
-                               )]
+                                     TStringValue(str_val='{c,d,e}',
+                                                  is_null=None)])]
 
         assert result == expected
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -20,6 +20,19 @@ class TestLoaders(object):
 
         assert result == expected
 
+    def test_build_input_rows_with_array(self):
+        data = [(1, 'a'), (2, 'b'), (3, ['c', 'd', 'e'])]
+        result = _build_input_rows(data)
+        expected = [TStringRow(cols=[TStringValue(str_val='1', is_null=None),
+                                     TStringValue(str_val='a', is_null=None)]),
+                    TStringRow(cols=[TStringValue(str_val='2', is_null=None),
+                                     TStringValue(str_val='b', is_null=None)]),
+                    TStringRow(cols=[TStringValue(str_val='3', is_null=None),
+                                     TStringValue(str_val='{1,2,3}', is_null=None)]
+                               )]
+
+        assert result == expected
+
     def test_build_table_columnar(self):
         pd = pytest.importorskip("pandas")
         pytest.importorskip("pyarrow")

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -28,7 +28,7 @@ class TestLoaders(object):
                     TStringRow(cols=[TStringValue(str_val='2', is_null=None),
                                      TStringValue(str_val='b', is_null=None)]),
                     TStringRow(cols=[TStringValue(str_val='3', is_null=None),
-                                     TStringValue(str_val='{1,2,3}', is_null=None)]
+                                     TStringValue(str_val='{c,d,e}', is_null=None)]
                                )]
 
         assert result == expected


### PR DESCRIPTION
This is a pull request to handle ingestion of array types using the load_table_rowwise function.

MapD expects arrays to be string formatted as "{value1,value2,value3,...}".