### PR TITLE
Consolidate build environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - ci/install-travis.sh
 script:
   - echo "script start"
-  - source activate test-environment
+  - source activate omnisci-dev
   - pytest tests
   - flake8
   - source ./ci/build_pymapd.sh

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -24,25 +24,18 @@ echo
 echo "[add channels]"
 conda config --add channels conda-forge || exit 1
 
-conda create -q -n test-environment python=${PYTHON}
-source activate test-environment
+conda create -q -f environment.yml python=${PYTHON}
+source activate omnisci-dev
 
+#list of dev packages not needed for general conda environment.yml file
 conda install -q \
-      six \
-      thrift=0.11.0 \
       coverage \
       flake8 \
       pytest=3.3.1 \
       pytest-cov \
       pytest-mock \
-      sqlalchemy \
-      mock \
-      pyarrow=0.10.0 \
-      arrow-cpp=0.10.0 \
-      cython \
-      numpy \
-      pandas
+      mock
 
 pip install -e .
-conda list test-environment
+conda list omnisci-dev
 exit 0

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -24,7 +24,7 @@ echo
 echo "[add channels]"
 conda config --add channels conda-forge || exit 1
 
-conda create -q -f environment.yml python=${PYTHON}
+conda env create -q -f environment.yml python=${PYTHON}
 source activate omnisci-dev
 
 #list of dev packages not needed for general conda environment.yml file

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -4,7 +4,7 @@ echo "[install-travis]"
 
 # install iniconda
 MINICONDA_DIR="$HOME/miniconda3"
-time wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh || exit 1
+time wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh || exit 1
 time bash miniconda.sh -b -p "$MINICONDA_DIR" || exit 1
 
 echo
@@ -24,7 +24,7 @@ echo
 echo "[add channels]"
 conda config --add channels conda-forge || exit 1
 
-conda env create -q -f environment.yml python=${PYTHON}
+conda env create -f environment.yml python=${PYTHON}
 source activate omnisci-dev
 
 #list of dev packages not needed for general conda environment.yml file

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
 - thrift=0.11.0
 - numpydoc
 - cython
-- pyarrow=0.7.1
-- arrow-cpp=0.7.1
+- pyarrow=0.10.0
+- arrow-cpp=0.10.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
 - six>=1.10.0
 - thrift=0.11.0
 - numpydoc
-- cython
 - pyarrow=0.10.0
 - arrow-cpp=0.10.0
 - sqlalchemy

--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,16 @@
-name: mapd-dev-docs
+name: omnisci-dev
 channels:
 - conda-forge
 - defaults
 dependencies:
 - python=3.5
-- six=1.10.0
+- six>=1.10.0
 - thrift=0.11.0
 - numpydoc
 - cython
 - pyarrow=0.10.0
 - arrow-cpp=0.10.0
 - sqlalchemy
+- cython
+- numpy
+- pandas


### PR DESCRIPTION
Proposed fix for #102 

This should be just a re-organization of files, except for floating the version of `six`. I ran into an issue with having six pinned when trying to use H204GPU, and in this case, it doesn't seem like six is a dependency we need a hard pin for.