### PR TITLE
Change back to np.frombuffer

### DIFF
--- a/pymapd/_parsers.py
+++ b/pymapd/_parsers.py
@@ -180,7 +180,7 @@ def _parse_tdf_gpu(tdf):
 
     schema_buffer = load_buffer(tdf.sm_handle, tdf.sm_size)
     # TODO: extra copy.
-    schema_buffer = np.py_buffer(schema_buffer.to_pybytes(), dtype=np.uint8)
+    schema_buffer = np.frombuffer(schema_buffer.to_pybytes(), dtype=np.uint8)
 
     dtype = np.dtype(np.byte)
     darr = cuda.devicearray.DeviceNDArray(shape=dptr.size,


### PR DESCRIPTION
Fixes #105, which in v0.5.0 errored on `select_ipc_gpu`. Tested locally on a GPU-enabled instance and it works as expected.