### PR TITLE
Remove NumPy shim, replace with pa.foreign_buffer

### DIFF
--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -289,11 +289,9 @@ class Connection(object):
         -----
         This method requires pandas and pyarrow to be installed
         """
-        try:
-            import pyarrow  # noqa
-        except ImportError:
+        if not _HAS_ARROW:
             raise ImportError("pyarrow is required for `select_ipc`")
-
+            
         try:
             import pandas  # noqa
         except ImportError:

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -315,6 +315,10 @@ class Connection(object):
 
         schema = _load_schema(sm_buf)
         df = _load_data(df_buf, schema, tdf)
+        
+        #Deallocate TDataFrame at OmniSci instance
+        self.deallocate_ipc(df)
+        
         return df
 
     def deallocate_ipc_gpu(self, df, device_id=0):

--- a/pymapd/shm.pyx
+++ b/pymapd/shm.pyx
@@ -2,7 +2,6 @@ cimport numpy as np
 import numpy as np
 import pyarrow as pa
 from numpy cimport ndarray
-from cython cimport view
 import pyarrow as pa
 from libc.stdint cimport uintptr_t
 

--- a/pymapd/shm.pyx
+++ b/pymapd/shm.pyx
@@ -41,5 +41,15 @@ cpdef load_buffer(bytes handle, int size):
 
     return pabuff
 
-
-    return pabuff
+#pa.cuda.foreign_buffer in pyarrow 0.11.0
+#cpdef load_buffer_gpu(bytes handle, int size):
+#
+#    shmkey = <unsigned int>ndarray(shape=1, dtype=np.uint32, buffer=handle)[0]
+#    shmid = shmget(shmkey, size, 0)
+#    if shmid == -1:
+#        raise ValueError("Invalid shared memory key {}".format(shmkey))
+#    ptr = shmat(shmid, NULL, 0)    # shared memory segment's start address
+#
+#    pabuff = pa.cuda.foreign_buffer(<uintptr_t>ptr, size, None)
+#
+#    return pabuff

--- a/pymapd/shm.pyx
+++ b/pymapd/shm.pyx
@@ -36,15 +36,10 @@ cpdef load_buffer(bytes handle, int size):
     if shmid == -1:
         raise ValueError("Invalid shared memory key {}".format(shmkey))
     ptr = shmat(shmid, NULL, 0)    # shared memory segment's start address
- 
+
     pabuff = pa.foreign_buffer(<uintptr_t>ptr, size, None)
 
-    # release
-    # How best to handle failures here?
-    rm_status = shmctl(shmid, IPC_RMID, NULL)
+    return pabuff
 
-    status = shmdt(ptr)
-    if status == -1:
-        raise TypeError("Could not release shared memory")
 
     return pabuff

--- a/pymapd/shm.pyx
+++ b/pymapd/shm.pyx
@@ -4,6 +4,7 @@ import pyarrow as pa
 from numpy cimport ndarray
 from cython cimport view
 import pyarrow as pa
+from libc.stdint cimport uintptr_t
 
 # ------------------------
 # Shared Memory Wrappers #
@@ -35,11 +36,8 @@ cpdef load_buffer(bytes handle, int size):
     if shmid == -1:
         raise ValueError("Invalid shared memory key {}".format(shmkey))
     ptr = shmat(shmid, NULL, 0)    # shared memory segment's start address
-    # TODO: remove this intermediate NumPy step. Should be easy
-    # well, maybe not so easy, since I think this is causing a copy,
-    # which is allowing be to detach the shared memory segment immediately
-    npbuff = np.asarray(<np.uint8_t[:size]>ptr, dtype=np.uint8)
-    pabuff = pa.py_buffer(npbuff.tobytes())
+ 
+    pabuff = pa.foreign_buffer(<uintptr_t>ptr, size, None)
 
     # release
     # How best to handle failures here?

--- a/pymapd/shm.pyx
+++ b/pymapd/shm.pyx
@@ -1,9 +1,6 @@
-cimport numpy as np
-import numpy as np
-import pyarrow as pa
-from numpy cimport ndarray
 import pyarrow as pa
 from libc.stdint cimport uintptr_t
+import struct
 
 # ------------------------
 # Shared Memory Wrappers #
@@ -30,7 +27,7 @@ cdef extern from "sys/shm.h":
 
 cpdef load_buffer(bytes handle, int size):
 
-    shmkey = <unsigned int>ndarray(shape=1, dtype=np.uint32, buffer=handle)[0]
+    shmkey = struct.unpack('<L', handle)[0]
     shmid = shmget(shmkey, size, 0)
     if shmid == -1:
         raise ValueError("Invalid shared memory key {}".format(shmkey))
@@ -43,7 +40,7 @@ cpdef load_buffer(bytes handle, int size):
 #pa.cuda.foreign_buffer in pyarrow 0.11.0
 #cpdef load_buffer_gpu(bytes handle, int size):
 #
-#    shmkey = <unsigned int>ndarray(shape=1, dtype=np.uint32, buffer=handle)[0]
+#    shmkey = struct.unpack('<L', handle)[0]
 #    shmid = shmget(shmkey, size, 0)
 #    if shmid == -1:
 #        raise ValueError("Invalid shared memory key {}".format(shmkey))


### PR DESCRIPTION
Work thus far has been on the CPU side of things, as needed functionality for GPU (`pa.cuda.foreign_buffer`) is in pyarrow 0.11.0 (we're on 0.10.0 for pygdf compatibiity).

Removed all NumPy code from shim. It might not be possible to completely get rid of NumPy as a dependency until we move to pyarrow 0.11 AND cuDF. Worth revisiting down the line.

Moved memory deallocation from inside `load_buffer` to  `select_ipc`, deferring to `deallocate_df` method from Thrift rather than use shmget/shmctl and friends