### PR TITLE
Option to chunk Pandas columnar data load

### DIFF
--- a/pymapd/_pandas_loaders.py
+++ b/pymapd/_pandas_loaders.py
@@ -91,7 +91,7 @@ def thrift_cast(data, mapd_type):
         return data.astype(int)
 
 
-def build_input_columnar(df, chunk_size_bytes=0, preserve_index=True):
+def build_input_columnar(df, preserve_index=True, chunk_size_bytes=0):
     if preserve_index:
         df = df.reset_index()
 

--- a/pymapd/_pandas_loaders.py
+++ b/pymapd/_pandas_loaders.py
@@ -62,7 +62,11 @@ def get_mapd_type_from_object(data):
         return 'DATE'
     elif isinstance(val, datetime.time):
         return 'TIME'
+    elif isinstance(val, bool):
+        return 'BOOL'
     elif isinstance(val, int):
+        if data.max() >= 2147483648 or data.min() <= -2147483648:
+            return 'BIGINT'
         return 'INT'
     else:
         raise TypeError("Unhandled type {}".format(data.dtype))
@@ -79,6 +83,9 @@ def thrift_cast(data, mapd_type):
     elif mapd_type == 'DATE':
         return date_to_seconds(data)
     elif mapd_type == 'BOOL':
+        # fillna before converting to int, since int cols
+        # in Pandas do not support None or NaN
+        data = data.fillna(mapd_to_na[mapd_type])
         return data.astype(int)
 
 

--- a/pymapd/_pandas_loaders.py
+++ b/pymapd/_pandas_loaders.py
@@ -94,9 +94,13 @@ def thrift_cast(data, mapd_type):
 def build_input_columnar(df, chunk_size_bytes=0, preserve_index=True):
     if preserve_index:
         df = df.reset_index()
-    
+
     dfsize = df.memory_usage().sum()
-    chunks = math.ceil(dfsize / chunk_size_bytes) if chunk_size_bytes > 0 else 1
+    if chunk_size_bytes > 0:
+        chunks = math.ceil(dfsize / chunk_size_bytes)
+    else:
+        chunks = 1
+
     dfs = (np.array_split(df, chunks))
     cols_array = []
     for df in dfs:

--- a/pymapd/_utils.py
+++ b/pymapd/_utils.py
@@ -20,7 +20,7 @@ def datetime_to_seconds(arr):
     import numpy as np
 
     if arr.dtype != np.dtype('datetime64[ns]'):
-        raise TypeError("Invalid type {}, expected datetime64[ns]".foramt(
+        raise TypeError("Invalid type {}, expected datetime64[ns]".format(
             arr.dtype))
     return arr.view('i8') // 10**9  # ns -> s since epoch
 
@@ -57,8 +57,8 @@ mapd_to_slot = {
 
 
 mapd_to_na = {
-    'BOOL': 0,
-    'BOOLEAN': 0,
+    'BOOL': -128,
+    'BOOLEAN': -128,
     'SMALLINT': -32768,
     'INT': -2147483648,
     'INTEGER': -2147483648,

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -499,7 +499,13 @@ class Connection(object):
         input_data = _build_input_rows(data)
         self._client.load_table(self._session, table_name, input_data)
 
-    def load_table_columnar(self, table_name, data, preserve_index=False):
+    def load_table_columnar(
+            self,
+            table_name,
+            data,
+            chunk_size_bytes=0,
+            preserve_index=False
+    ):
         """Load a pandas DataFrame to the database using MapD's Thrift-based
         columnar format
 
@@ -509,6 +515,10 @@ class Connection(object):
         data : DataFrame
         preserve_index : bool, default False
             Whether to include the index of a pandas DataFrame when writing.
+        chunk_size_bytes : integer, default 0
+            Chunk the loading of columns to prevent large Thrift requests. A
+            value of 0 means do not chunk and send the dataframe as a single
+            request
 
         Examples
         --------
@@ -525,12 +535,15 @@ class Connection(object):
 
         if _is_pandas(data):
             input_cols = _pandas_loaders.build_input_columnar(
-                data, preserve_index=preserve_index
+                data,
+                chunk_size_bytes=chunk_size_bytes,
+                preserve_index=preserve_index
             )
         else:
             raise TypeError("Unknown type {}".format(type(data)))
-        self._client.load_table_binary_columnar(self._session, table_name,
-                                                input_cols)
+        for cols in input_cols:
+            self._client.load_table_binary_columnar(self._session, table_name,
+                                                    cols)
 
     def load_table_arrow(self, table_name, data, preserve_index=False):
         """Load a pandas.DataFrame or a pyarrow Table or RecordBatch to the

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -503,8 +503,8 @@ class Connection(object):
             self,
             table_name,
             data,
-            chunk_size_bytes=0,
-            preserve_index=False
+            preserve_index=False,
+            chunk_size_bytes=0
     ):
         """Load a pandas DataFrame to the database using MapD's Thrift-based
         columnar format

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -536,8 +536,8 @@ class Connection(object):
         if _is_pandas(data):
             input_cols = _pandas_loaders.build_input_columnar(
                 data,
-                chunk_size_bytes=chunk_size_bytes,
-                preserve_index=preserve_index
+                preserve_index=preserve_index,
+                chunk_size_bytes=chunk_size_bytes
             )
         else:
             raise TypeError("Unknown type {}".format(type(data)))

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -32,7 +32,7 @@ class TestLoaders(object):
             TColumn(TColumnData(int_col=[1, 2, 3]), nulls=nulls),
             TColumn(TColumnData(real_col=[1.1, 2.2, 3.3]), nulls=nulls)
         ]
-        assert_columnar_equal(result, expected)
+        assert_columnar_equal(result[0], expected)
 
     def test_build_table_columnar_pandas(self):
         import pandas as pd
@@ -70,7 +70,7 @@ class TestLoaders(object):
             TColumn(TColumnData(int_col=[1451606400, 1483228800]), nulls=nulls),  # noqa
             TColumn(TColumnData(int_col=[1451606400, 1483228800]), nulls=nulls)
         ]
-        assert_columnar_equal(result, expected)
+        assert_columnar_equal(result[0], expected)
 
     def test_build_table_columnar_nulls(self):
         import pandas as pd
@@ -116,7 +116,7 @@ class TestLoaders(object):
             TColumn(TColumnData(int_col=[1451606400, 1483228800, ns_na]), nulls=nulls),  # noqa
             TColumn(TColumnData(int_col=[1451606400, 1483228800, bigint_na]), nulls=nulls)  # noqa
         ]
-        assert_columnar_equal(result, expected)
+        assert_columnar_equal(result[0], expected)
 
     def test_build_row_desc(self):
         pd = pytest.importorskip("pandas")

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -78,7 +78,14 @@ class TestLoaders(object):
 
         data = pd.DataFrame({
             "boolean_": [True, False, None],
-            "bigint_": np.array([0, 1, None], dtype=np.object),
+            # Currently Pandas does not support storing None or NaN
+            # in integer columns, so int cols with null
+            # need to be objects. This means our type detection will be
+            # unreliable since if there is no number outside the int32
+            # bounds in a column with nulls then we will be assuming int
+            "int_": np.array([0, 1, None], dtype=np.object),
+            "bigint_": np.array([0, 9223372036854775807, None],
+                                dtype=np.object),
             "double_": np.array([0, 1, None], dtype=np.float64),
             "varchar_": ["a", "b", None],
             "text_": ['a', 'b', None],
@@ -86,20 +93,22 @@ class TestLoaders(object):
             "timestamp_": [pd.Timestamp("2016"), pd.Timestamp("2017"), None],
             "date_": [datetime.date(2016, 1, 1), datetime.date(2017, 1, 1),
                       None],
-        }, columns=['boolean_', 'bigint_',
+        }, columns=['boolean_', 'int_', 'bigint_',
                     'double_', 'varchar_', 'text_', 'time_', 'timestamp_',
                     'date_'])
         result = _pandas_loaders.build_input_columnar(data,
                                                       preserve_index=False)
 
         nulls = [False, False, True]
+        bool_na = -128
         int_na = -2147483648
         bigint_na = -9223372036854775808
         ns_na = -9223372037
 
         expected = [
-            TColumn(TColumnData(int_col=[1, 0, int_na]), nulls=nulls),
-            TColumn(TColumnData(int_col=np.array([0, 1, int_na], dtype=np.int64)), nulls=nulls),  # noqa
+            TColumn(TColumnData(int_col=[1, 0, bool_na]), nulls=nulls),
+            TColumn(TColumnData(int_col=np.array([0, 1, int_na], dtype=np.int32)), nulls=nulls),  # noqa
+            TColumn(TColumnData(int_col=np.array([0, 9223372036854775807, bigint_na], dtype=np.int64)), nulls=nulls),  # noqa
             TColumn(TColumnData(real_col=np.array([0, 1, np.nan], dtype=np.float64)), nulls=nulls),  # noqa
             TColumn(TColumnData(str_col=['a', 'b', '']), nulls=nulls),
             TColumn(TColumnData(str_col=['a', 'b', '']), nulls=nulls),


### PR DESCRIPTION
This adds the ability to specify a size in bytes of the Pandas dataframe that gets split into, creating an array of Thrift data for insert into OmniSci.

This is for situations where either there is a limit on the request size to the OmniSci server, or other situations where it is undesirable to be sending a single enormous request for perhaps a long period of time (eg. in situations where a re-run of a process detects the existing data and continues on from where it left off)