### PR TITLE
Update Thrift bindings and remove ununsed imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,12 @@ services:
   - docker
 language: python
 env:
-  # generated with
-  # anaconda login pymapd
-  # anaconda auth -n travis-upload-key -o pymapd --create
-  # travis encrypt <key>
-  global:
-    secure: "DOR4RTMOLjOq2kNLy2OC5HYgsMyzB7JFuebtw6Wrl4PzuQDqSKLODYuiTFMEEyqrljcoNo1BaC3Gtirl4uMynxrb6wgB/d+nddz5cX6HeHhllFbLR6dXAxM/k3BfnXPcNCuW+1a2bxKVFrLTF0La4XfKCX5uJv+p2Yu2sSVplUgfDq/HlvWPloGuH+PVSpihyqtycafMvwK4c8d9/DfdNpH3AnQRr47EJ2jeCz7QvEsHF86rhyBFnMdT02Sgw3efHaDVwKzgHQaGgBoOT+sy3cj4/yYwu+WIC7a0WmeKupqYTpLdRM2A+vrBpu0KAd4lyRuYFcq4DHMe9jaKpca0+b0t7bAFaluV4Z4nnuxmJFJsiYa7vDXvr0/Ge+n3UjykX4E0WfDDsbNTHmeYJR2fYkeyYBv26COT5DrrCoX2M9wtM6ndSG7HAG6NqJCs2pbvR70zx1+GPei1vClqw+hZ6FgBQFXdgVVDsiFhAjaFTeiJCHTw1edX7dtA5M/SbHlYYEibuK2VlfxK1ALkimXjTwhsGdTx18W27UlwNA1FMmHvR1AMXWcdwUoKAfa0T3eaSuoPYp88XZ7otEYar7wX+RQR1i1ePBQNdPKFBeBGQo0Wc8flRxtJit624845F1Gh+4HhTwj7+P11AeBeuwMZr8gSW7wBNOjjxsZKj8bibCE="
   matrix:
     - PYTHON=3.6
     - PYTHON=3.5
     - PYTHON=2.7
 before_install:
-  - docker pull mapd/core-os-cpu
+  - docker pull mapd/core-os-cpu:latest
   - docker run -d --ipc=host -v /dev:/dev -p 9091:9091 --name=mapd mapd/core-os-cpu:latest
   - docker ps -a
   - export PATH="$HOME/miniconda3/bin:$PATH"
@@ -25,7 +19,3 @@ script:
   - source activate omnisci-dev
   - pytest tests
   - flake8
-  - source ./ci/build_pymapd.sh
-
-after_success:
-  - source ./ci/upload-anaconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
     - PYTHON=3.5
     - PYTHON=2.7
 before_install:
-  - docker pull mapd/core-os-cpu
-  - docker run -d --ipc=host -v /dev:/dev -p 9091:9091 --name=mapd mapd/core-os-cpu:latest
+  - docker pull mapd/core-os-cpu:v4.3.0
+  - docker run -d --ipc=host -v /dev:/dev -p 9091:9091 --name=mapd mapd/core-os-cpu:v4.3.0
   - docker ps -a
   - export PATH="$HOME/miniconda3/bin:$PATH"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
     - PYTHON=3.5
     - PYTHON=2.7
 before_install:
-  - docker pull mapd/core-os-cpu:v4.3.0
-  - docker run -d --ipc=host -v /dev:/dev -p 9091:9091 --name=mapd mapd/core-os-cpu:v4.3.0
+  - docker pull mapd/core-os-cpu
+  - docker run -d --ipc=host -v /dev:/dev -p 9091:9091 --name=mapd mapd/core-os-cpu:latest
   - docker ps -a
   - export PATH="$HOME/miniconda3/bin:$PATH"
 install:

--- a/mapd/MapD-remote
+++ b/mapd/MapD-remote
@@ -48,6 +48,7 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
     print('  void set_table_epoch_by_name(TSessionId session, string table_name, i32 new_epoch)')
     print('  i32 get_table_epoch(TSessionId session, i32 db_id, i32 table_id)')
     print('  i32 get_table_epoch_by_name(TSessionId session, string table_name)')
+    print('  TSessionInfo get_session_info(TSessionId session)')
     print('  TQueryResult sql_execute(TSessionId session, string query, bool column_format, string nonce, i32 first_n, i32 at_most_n)')
     print('  TDataFrame sql_execute_df(TSessionId session, string query, TDeviceType device_type, i32 device_id, i32 first_n)')
     print('  TDataFrame sql_execute_gdf(TSessionId session, string query, i32 device_id, i32 first_n)')
@@ -76,17 +77,18 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
     print('  void load_table_binary_arrow(TSessionId session, string table_name, string arrow_stream)')
     print('  void load_table(TSessionId session, string table_name,  rows)')
     print('  TDetectResult detect_column_types(TSessionId session, string file_name, TCopyParams copy_params)')
-    print('  void create_table(TSessionId session, string table_name, TRowDescriptor row_desc, TTableType table_type)')
+    print('  void create_table(TSessionId session, string table_name, TRowDescriptor row_desc, TTableType table_type, TCreateParams create_params)')
     print('  void import_table(TSessionId session, string table_name, string file_name, TCopyParams copy_params)')
     print('  void import_geo_table(TSessionId session, string table_name, string file_name, TCopyParams copy_params, TRowDescriptor row_desc)')
     print('  TImportStatus import_table_status(TSessionId session, string import_id)')
     print('  string get_first_geo_file_in_archive(TSessionId session, string archive_path, TCopyParams copy_params)')
     print('   get_all_files_in_archive(TSessionId session, string archive_path, TCopyParams copy_params)')
+    print('  TTableMeta check_table_consistency(TSessionId session, i32 table_id)')
     print('  TPendingQuery start_query(TSessionId session, string query_ra, bool just_explain)')
     print('  TStepResult execute_first_step(TPendingQuery pending_query)')
-    print('  void broadcast_serialized_rows(string serialized_rows, TRowDescriptor row_desc, TQueryId query_id)')
+    print('  void broadcast_serialized_rows(string serialized_rows, TRowDescriptor row_desc, i64 uncompressed_size, TQueryId query_id)')
     print('  TPendingRenderQuery start_render_query(TSessionId session, i64 widget_id, i16 node_idx, string vega_json)')
-    print('  TRenderStepResult execute_next_render_step(TPendingRenderQuery pending_render, TRenderDataAggMap merged_data)')
+    print('  TRenderStepResult execute_next_render_step(TPendingRenderQuery pending_render, TRenderAggDataMap merged_data)')
     print('  void insert_data(TSessionId session, TInsertData insert_data)')
     print('  void checkpoint(TSessionId session, i32 db_id, i32 table_id)')
     print('  TTableDescriptor get_table_descriptor(TSessionId session, string table_name)')
@@ -95,6 +97,7 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
     print('   get_db_objects_for_grantee(TSessionId session, string roleName)')
     print('   get_db_object_privs(TSessionId session, string objectName, TDBObjectType type)')
     print('   get_all_roles_for_user(TSessionId session, string userName)')
+    print('  bool has_object_privilege(TSessionId session, string granteeName, string ObjectName, TDBObjectType objectType, TDBObjectPermissions permissions)')
     print('  TLicenseInfo set_license_key(TSessionId session, string key, string nonce)')
     print('  TLicenseInfo get_license_claims(TSessionId session, string nonce)')
     print('')
@@ -320,6 +323,12 @@ elif cmd == 'get_table_epoch_by_name':
         sys.exit(1)
     pp.pprint(client.get_table_epoch_by_name(eval(args[0]), args[1],))
 
+elif cmd == 'get_session_info':
+    if len(args) != 1:
+        print('get_session_info requires 1 args')
+        sys.exit(1)
+    pp.pprint(client.get_session_info(eval(args[0]),))
+
 elif cmd == 'sql_execute':
     if len(args) != 6:
         print('sql_execute requires 6 args')
@@ -489,10 +498,10 @@ elif cmd == 'detect_column_types':
     pp.pprint(client.detect_column_types(eval(args[0]), args[1], eval(args[2]),))
 
 elif cmd == 'create_table':
-    if len(args) != 4:
-        print('create_table requires 4 args')
+    if len(args) != 5:
+        print('create_table requires 5 args')
         sys.exit(1)
-    pp.pprint(client.create_table(eval(args[0]), args[1], eval(args[2]), eval(args[3]),))
+    pp.pprint(client.create_table(eval(args[0]), args[1], eval(args[2]), eval(args[3]), eval(args[4]),))
 
 elif cmd == 'import_table':
     if len(args) != 4:
@@ -524,6 +533,12 @@ elif cmd == 'get_all_files_in_archive':
         sys.exit(1)
     pp.pprint(client.get_all_files_in_archive(eval(args[0]), args[1], eval(args[2]),))
 
+elif cmd == 'check_table_consistency':
+    if len(args) != 2:
+        print('check_table_consistency requires 2 args')
+        sys.exit(1)
+    pp.pprint(client.check_table_consistency(eval(args[0]), eval(args[1]),))
+
 elif cmd == 'start_query':
     if len(args) != 3:
         print('start_query requires 3 args')
@@ -537,10 +552,10 @@ elif cmd == 'execute_first_step':
     pp.pprint(client.execute_first_step(eval(args[0]),))
 
 elif cmd == 'broadcast_serialized_rows':
-    if len(args) != 3:
-        print('broadcast_serialized_rows requires 3 args')
+    if len(args) != 4:
+        print('broadcast_serialized_rows requires 4 args')
         sys.exit(1)
-    pp.pprint(client.broadcast_serialized_rows(args[0], eval(args[1]), eval(args[2]),))
+    pp.pprint(client.broadcast_serialized_rows(args[0], eval(args[1]), eval(args[2]), eval(args[3]),))
 
 elif cmd == 'start_render_query':
     if len(args) != 4:
@@ -601,6 +616,12 @@ elif cmd == 'get_all_roles_for_user':
         print('get_all_roles_for_user requires 2 args')
         sys.exit(1)
     pp.pprint(client.get_all_roles_for_user(eval(args[0]), args[1],))
+
+elif cmd == 'has_object_privilege':
+    if len(args) != 5:
+        print('has_object_privilege requires 5 args')
+        sys.exit(1)
+    pp.pprint(client.has_object_privilege(eval(args[0]), args[1], args[2], eval(args[3]), eval(args[4]),))
 
 elif cmd == 'set_license_key':
     if len(args) != 3:

--- a/mapd/MapD.py
+++ b/mapd/MapD.py
@@ -6,8 +6,7 @@
 #  options string: py
 #
 
-from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
-from thrift.protocol.TProtocol import TProtocolException
+from thrift.Thrift import TType, TMessageType, TApplicationException
 from thrift.TRecursive import fix_spec
 
 import sys

--- a/mapd/constants.py
+++ b/mapd/constants.py
@@ -5,10 +5,3 @@
 #
 #  options string: py
 #
-
-from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
-from thrift.protocol.TProtocol import TProtocolException
-from thrift.TRecursive import fix_spec
-
-import sys
-from .ttypes import *

--- a/mapd/ttypes.py
+++ b/mapd/ttypes.py
@@ -6,8 +6,7 @@
 #  options string: py
 #
 
-from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
-from thrift.protocol.TProtocol import TProtocolException
+from thrift.Thrift import TType, TException, TApplicationException
 from thrift.TRecursive import fix_spec
 
 import sys

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -398,7 +398,7 @@ class Connection(object):
 
         row_desc = build_row_desc(data, preserve_index=preserve_index)
         self._client.create_table(self._session, table_name, row_desc,
-                                  TTableType.DELIMITED, TCreateParams())
+                                  TTableType.DELIMITED, TCreateParams(False))
 
     def load_table(self, table_name, data, method='infer',
                    preserve_index=False,

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -11,9 +11,8 @@ from sqlalchemy.engine.url import make_url
 from thrift.protocol import TBinaryProtocol, TJSONProtocol
 from thrift.transport import TSocket, THttpClient, TTransport
 from thrift.transport.TSocket import TTransportException
-from mapd.MapD import Client
+from mapd.MapD import Client, TDeviceType, TCreateParams
 from mapd.ttypes import TMapDException
-from mapd.MapD import TDeviceType
 
 from .cursor import Cursor
 from .exceptions import _translate_exception, OperationalError
@@ -399,7 +398,7 @@ class Connection(object):
 
         row_desc = build_row_desc(data, preserve_index=preserve_index)
         self._client.create_table(self._session, table_name, row_desc,
-                                  TTableType.DELIMITED)
+                                  TTableType.DELIMITED, TCreateParams())
 
     def load_table(self, table_name, data, method='infer',
                    preserve_index=False,


### PR DESCRIPTION
Fixes #116 by removing imports that are aren't being used from the thrift files. This is a minor fix, as it really becomes an issue when trying to use thrift via R via the Python bindings.

Will leave open until #141 can be evaluated with a new Docker build (i.e. this PR not expected to break things, but better to wait than assume nothing else fails)