### PR TITLE
Check more versions of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ services:
   - docker
 language: python
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
   - "3.7"
+  - "3.6"
+  - "3.5"
+  - "3.4"
+  - "2.7"
 matrix:
   allow_failures:
-    - "3.7"
+  - python: "3.7"
 before_install:
   - docker pull mapd/core-os-cpu:latest
   - docker run -d --ipc=host -v /dev:/dev -p 9091:9091 --name=mapd mapd/core-os-cpu:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@ services:
 language: python
 os:
   - linux
-  - osx
 env:
   matrix:
     - PYTHON=3.6
     - PYTHON=3.5
     - PYTHON=3.4
     - PYTHON=2.7
-  allow_failures:
+    allow_failures:
     - PYTHON=3.7
 before_install:
   - docker pull mapd/core-os-cpu:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 matrix:
   allow_failures:
-    -"3.7"
+    - "3.7"
 before_install:
   - docker pull mapd/core-os-cpu:latest
   - docker run -d --ipc=host -v /dev:/dev -p 9091:9091 --name=mapd mapd/core-os-cpu:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ sudo: required
 services:
   - docker
 language: python
-env:
-  matrix:
-    - PYTHON=3.6
-    - PYTHON=3.5
-    - PYTHON=3.4
-    - PYTHON=2.7
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+matrix:
+  allow_failures:
+    -"3.7"
 before_install:
   - docker pull mapd/core-os-cpu:latest
   - docker run -d --ipc=host -v /dev:/dev -p 9091:9091 --name=mapd mapd/core-os-cpu:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,17 @@ sudo: required
 services:
   - docker
 language: python
+os:
+  - linux
+  - osx
 env:
   matrix:
     - PYTHON=3.6
     - PYTHON=3.5
+    - PYTHON=3.4
     - PYTHON=2.7
+  allow_failures:
+    - PYTHON=3.7
 before_install:
   - docker pull mapd/core-os-cpu:latest
   - docker run -d --ipc=host -v /dev:/dev -p 9091:9091 --name=mapd mapd/core-os-cpu:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,12 @@ sudo: required
 services:
   - docker
 language: python
-os:
-  - linux
 env:
   matrix:
     - PYTHON=3.6
     - PYTHON=3.5
     - PYTHON=3.4
     - PYTHON=2.7
-    allow_failures:
-    - PYTHON=3.7
 before_install:
   - docker pull mapd/core-os-cpu:latest
   - docker run -d --ipc=host -v /dev:/dev -p 9091:9091 --name=mapd mapd/core-os-cpu:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: xenial
 services:
   - docker
 language: python

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -31,7 +31,7 @@ source activate omnisci-dev
 conda install -q \
       coverage \
       flake8 \
-      pytest>=3.3.1 \
+      pytest=3.* \
       pytest-cov \
       pytest-mock \
       mock

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -24,14 +24,14 @@ echo
 echo "[add channels]"
 conda config --add channels conda-forge || exit 1
 
-conda env create -f environment.yml python=${PYTHON}
+conda env create -f environment.yml python=${TRAVIS_PYTHON_VERSION}
 source activate omnisci-dev
 
 #list of dev packages not needed for general conda environment.yml file
 conda install -q \
       coverage \
       flake8 \
-      pytest=3.3.1 \
+      pytest>=3.3.1 \
       pytest-cov \
       pytest-mock \
       mock

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = ['six', 'thrift == 0.11.0', 'sqlalchemy', 'numpy', 'pandas',
 
 
 doc_requires = ['sphinx', 'numpydoc', 'sphinx-rtd-theme']
-test_requires = ['coverage', 'pytest == 3.3.1', 'pytest-mock']
+test_requires = ['coverage', 'pytest >= 3.3.1', 'pytest-mock']
 dev_requires = doc_requires + test_requires
 gpu_requires = ['cudf', 'libcudf']
 complete_requires = dev_requires + gpu_requires

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = ['six', 'thrift == 0.11.0', 'sqlalchemy', 'numpy', 'pandas',
 
 
 doc_requires = ['sphinx', 'numpydoc', 'sphinx-rtd-theme']
-test_requires = ['coverage', 'pytest >= 3.3.1', 'pytest-mock']
+test_requires = ['coverage', 'pytest = 3.*', 'pytest-mock']
 dev_requires = doc_requires + test_requires
 gpu_requires = ['cudf', 'libcudf']
 complete_requires = dev_requires + gpu_requires


### PR DESCRIPTION
In the setup.py file, we claim to support 3.4, and eventually we'll support 3.7. Add 3.4 in the required testing section, add 3.7 to be tested with the expectation it might fail (it can move out of `allow_failures` section when we formally support it)

~Additionally, test on OSX, just for another data point. There should be no OS-specific code in the package, but should test anyway.~ Travis doesn't support Python OSX builds for the time being