### PR TITLE
Test Python 3.4 and update pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   matrix:
     - PYTHON=3.6
     - PYTHON=3.5
+    - PYTHON=3.4
     - PYTHON=2.7
 before_install:
   - docker pull mapd/core-os-cpu:latest

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -31,7 +31,7 @@ source activate omnisci-dev
 conda install -q \
       coverage \
       flake8 \
-      pytest=3.3.1 \
+      pytest=3.6 \
       pytest-cov \
       pytest-mock \
       mock

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = ['six', 'thrift == 0.11.0', 'sqlalchemy', 'numpy', 'pandas',
 
 
 doc_requires = ['sphinx', 'numpydoc', 'sphinx-rtd-theme']
-test_requires = ['coverage', 'pytest == 3.3.1', 'pytest-mock']
+test_requires = ['coverage', 'pytest == 3.6', 'pytest-mock']
 dev_requires = doc_requires + test_requires
 gpu_requires = ['cudf', 'libcudf']
 complete_requires = dev_requires + gpu_requires


### PR DESCRIPTION
We claim to support Python 3.4 in the setup.py file, so we should test that is true.

Unrelated to Python 3.4, because we don't pin other pytest modules, a failure was occurring because pytest-cov stopped supporting pytest < 3.6. Updated pytest to 3.6 and pinned, so build passes. Should consider re-visiting test suite and updating as necessary (possibly during dropping of python 2?)