### PR TITLE
Add support for pyarrow 0.11 and python3.7, remove python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
     - PYTHON=3.7
     - PYTHON=3.6
     - PYTHON=3.5
-    - PYTHON=3.4
     - PYTHON=2.7
 before_install:
   - docker pull mapd/core-os-cpu:latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ services:
 language: python
 env:
   matrix:
+    - PYTHON=3.7
     - PYTHON=3.6
     - PYTHON=3.5
     - PYTHON=3.4

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -31,7 +31,7 @@ source activate omnisci-dev
 conda install -q \
       coverage \
       flake8 \
-      pytest>=3.6,<4.0 \
+      "pytest>=3.6,<4.0" \
       pytest-cov \
       pytest-mock \
       mock

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -24,7 +24,7 @@ echo
 echo "[add channels]"
 conda config --add channels conda-forge || exit 1
 
-conda env create -n omnisci-dev python=${PYTHON} \
+conda create -n omnisci-dev python=${PYTHON} \
 six>=1.10.0 \
 thrift=0.11.0 \
 numpydoc \

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -18,7 +18,7 @@ conda update -q conda
 
 echo
 echo "[conda build]"
-conda install conda-build anaconda-client conda-verify --python=${PYTHON}  --yes
+conda install conda-build anaconda-client conda-verify --yes
 
 echo
 echo "[add channels]"

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -6,6 +6,7 @@ echo "[install-travis]"
 MINICONDA_DIR="$HOME/miniconda3"
 time wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh || exit 1
 time bash miniconda.sh -b -p "$MINICONDA_DIR" || exit 1
+export PATH="$MINICONDA_DIR/bin:$PATH"
 
 echo
 echo "[show conda]"
@@ -24,17 +25,8 @@ echo
 echo "[add channels]"
 conda config --add channels conda-forge || exit 1
 
-conda env create -f environment.yml python=${PYTHON}
+conda env create -q -f environment.yml python=${PYTHON}
 source activate omnisci-dev
-
-#list of dev packages not needed for general conda environment.yml file
-conda install -q \
-      coverage \
-      flake8 \
-      "pytest>=3.6,<4.0" \
-      pytest-cov \
-      pytest-mock \
-      mock
 
 pip install -e .
 conda list omnisci-dev

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -38,4 +38,5 @@ conda install -q \
 
 pip install -e .
 conda list omnisci-dev
+echo
 exit 0

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -6,7 +6,6 @@ echo "[install-travis]"
 MINICONDA_DIR="$HOME/miniconda3"
 time wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh || exit 1
 time bash miniconda.sh -b -p "$MINICONDA_DIR" || exit 1
-export PATH="$MINICONDA_DIR/bin:$PATH"
 
 echo
 echo "[show conda]"
@@ -19,13 +18,28 @@ conda update -q conda
 
 echo
 echo "[conda build]"
-conda install conda-build anaconda-client conda-verify --yes
+conda install -q conda-build anaconda-client conda-verify --yes
 
 echo
 echo "[add channels]"
 conda config --add channels conda-forge || exit 1
 
-conda env create -q -f environment.yml python=${PYTHON}
+conda env create -n omnisci-dev python=${PYTHON} \
+six>=1.10.0 \
+thrift=0.11.0 \
+numpydoc \
+"pyarrow>=0.10.0,<0.12" \
+arrow-cpp \
+sqlalchemy \
+numpy>=1.14 \
+pandas \
+coverage \
+flake8 \
+"pytest>=3.6,<4.0" \
+pytest-cov \
+pytest-mock \
+mock
+
 source activate omnisci-dev
 
 pip install -e .

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -31,7 +31,7 @@ source activate omnisci-dev
 conda install -q \
       coverage \
       flake8 \
-      pytest=3.6 \
+      pytest>=3.6,<4.0 \
       pytest-cov \
       pytest-mock \
       mock

--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -18,7 +18,7 @@ conda update -q conda
 
 echo
 echo "[conda build]"
-conda install conda-build anaconda-client conda-verify --yes
+conda install conda-build anaconda-client conda-verify --python=${PYTHON}  --yes
 
 echo
 echo "[add channels]"

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python=3.6
+- python>=3.4,<3.8
 - six>=1.10.0
 - thrift=0.11.0
 - numpydoc

--- a/environment.yml
+++ b/environment.yml
@@ -3,11 +3,11 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python>=3.4,<3.8
+- "python>=3.4,<3.8"
 - six>=1.10.0
 - thrift=0.11.0
 - numpydoc
-- pyarrow>=0.10.0,<0.12
+- "pyarrow>=0.10.0,<0.12"
 - arrow-cpp
 - sqlalchemy
 - numpy>=1.14

--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,8 @@ dependencies:
 - six>=1.10.0
 - thrift=0.11.0
 - numpydoc
-- pyarrow=0.10.0
-- arrow-cpp=0.10.0
+- pyarrow>=0.10.0,<0.12
+- arrow-cpp
 - sqlalchemy
 - numpy>=1.14
 - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,6 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- "python>=3.4,<3.8"
 - six>=1.10.0
 - thrift=0.11.0
 - numpydoc

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python={$PYTHON}  
+- python=${PYTHON}  
 - six>=1.10.0
 - thrift=0.11.0
 - numpydoc

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,6 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python=${PYTHON}  
 - six>=1.10.0
 - thrift=0.11.0
 - numpydoc
@@ -12,3 +11,9 @@ dependencies:
 - sqlalchemy
 - numpy>=1.14
 - pandas
+- coverage
+- flake8
+- "pytest>=3.6,<4.0"
+- pytest-cov
+- pytest-mock
+- mock

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
 - conda-forge
 - defaults
 dependencies:
+- python={$PYTHON}  
 - six>=1.10.0
 - thrift=0.11.0
 - numpydoc

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = ['six', 'thrift == 0.11.0', 'sqlalchemy', 'numpy', 'pandas',
-                    'pyarrow == 0.10.0']
+                    'pyarrow >= 0.10.0,<0.12']
 
 # Optional Requirements
 
@@ -57,6 +57,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7'
     ],
     packages=['pymapd', 'mapd'],
     use_scm_version=True,

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ install_requires = ['six', 'thrift == 0.11.0', 'sqlalchemy', 'numpy', 'pandas',
 
 
 doc_requires = ['sphinx', 'numpydoc', 'sphinx-rtd-theme']
-test_requires = ['coverage', 'pytest == 3.6', 'pytest-mock']
+test_requires = ['coverage', 'pytest >= 3.6,<4.0', 'pytest-mock']
 dev_requires = doc_requires + test_requires
 gpu_requires = ['cudf', 'libcudf']
 complete_requires = dev_requires + gpu_requires


### PR DESCRIPTION
Purpose of PR is to allow for pymapd users to use pyarrow 0.11 and/or python 3.7 if they choose. Based on hard requirements of pymapd, this PR shows that choosing either or both is feasible.

Implementation specifies lower bound for pyarrow at 0.10 (current bound), but sets upper bound at <0.12 (just in case 0.12 changes binary compatibility). The only gotcha here is that if users choose to install cudf, pyarrow will need to downgrade to pyarrow 0.10 (unless cudf begins supporting pyarrow 0.11).

During the course of this PR, found that CI wasn't exactly working correctly, so fixed that as well. This highlighted that our dependency stack doesn't support Python 3.4, so it was removed.