### PR TITLE
Fix flake8 errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
   - echo "script start"
   - source activate omnisci-dev
   - pytest tests
-  - flake8
+  - flake8 --ignore=F401

--- a/pymapd/_loaders.py
+++ b/pymapd/_loaders.py
@@ -11,8 +11,7 @@ def _build_input_rows(data):
         input_row = TStringRow()
         input_row.cols = [
             TStringValue("{" + ",".join(str(y) for y in x) + "}")
-            if isinstance(x, collections.Sequence) and
-            not isinstance(x, str)
+            if isinstance(x, collections.Sequence) and not isinstance(x, str)
             else TStringValue(str(x)) for x in row
         ]
         input_data.append(input_row)

--- a/pymapd/_parsers.py
+++ b/pymapd/_parsers.py
@@ -76,9 +76,8 @@ def _extract_col_vals(desc, val):
         vals = [None if v is None else base + datetime.timedelta(seconds=v)
                 for v in vals]
     elif typename == 'DATE':
-        vals = [None if v is None else (base +
-                                        datetime.timedelta(seconds=v)).date()
-                for v in vals]
+        vals = [None if v is None else
+                (base + datetime.timedelta(seconds=v)).date() for v in vals]
     elif typename == 'TIME':
         vals = [None if v is None else seconds_to_time(v) for v in vals]
 

--- a/pymapd/_parsers.py
+++ b/pymapd/_parsers.py
@@ -12,6 +12,7 @@ from ._mutators import set_tdf, get_tdf
 from ._utils import seconds_to_time
 import numpy as np
 from .ipc import load_buffer, shmdt
+from typing import Any, List
 
 
 Description = namedtuple("Description", ["name", "type_code", "display_size",

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -6,6 +6,7 @@ import base64
 import pandas as pd
 import pyarrow as pa
 import ctypes
+from typing import Optional, Tuple
 
 from sqlalchemy.engine.url import make_url
 from thrift.protocol import TBinaryProtocol, TJSONProtocol

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -15,7 +15,7 @@ class Cursor:
         self.connection = connection
         self.columnar = columnar
         self.rowcount = -1
-        self._description = None  # type: Optional[List[Description]]
+        self._description = None  # type: Optional[List[str]]
         self._arraysize = 1
         self._result = None
         self._result_set = None  # type: Optional[Iterator[Any]]
@@ -34,7 +34,7 @@ class Cursor:
 
     @property
     def description(self):
-        # type: () -> Optional[List[Description]]
+        # type: () -> Optional[List[str]]
         """
         Read-only sequence describing columns of the result set.
         Each column is an instance of `Description` describing

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -1,5 +1,5 @@
 import mapd.ttypes as T
-from typing import Any, Optional, List, Description, Iterator, Union, Tuple, Iterable
+from typing import Any, Optional, List, Iterator, Union, Tuple, Iterable
 
 from .exceptions import _translate_exception
 from ._parsers import (_extract_col_vals, _extract_description,

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -1,5 +1,5 @@
 import mapd.ttypes as T
-from typing import Any, Optional, List, Description, Iterator, Union, Tuple
+from typing import Any, Optional, List, Description, Iterator, Union, Tuple, Iterable
 
 from .exceptions import _translate_exception
 from ._parsers import (_extract_col_vals, _extract_description,

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -1,4 +1,5 @@
 import mapd.ttypes as T
+from typing import Any, Optional, List, Description, Iterator, Union, Tuple
 
 from .exceptions import _translate_exception
 from ._parsers import (_extract_col_vals, _extract_description,

--- a/pymapd/dtypes.py
+++ b/pymapd/dtypes.py
@@ -3,6 +3,7 @@ https://www.python.org/dev/peps/pep-0249/#type-objects
 """
 import datetime
 import time
+from typing import Any, List
 
 from mapd import MapD
 


### PR DESCRIPTION
Fixes #168. Imports types used in type comments, but doesn't fix the underlying representation of types within the codebase.

Adding the ` --ignore=F401` flag to flake8 is because Python 3.5/flake doesn't trace through type imports when they are specified as comments (or something to that effect), so disabling for now. For #161, if type annotations are going to stay they should be done in Python 3 style and remove the ` --ignore=F401` flag