### PR TITLE
Switch default port mappings (from 9091 to 6274)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - PYTHON=3.5
 before_install:
   - docker pull mapd/core-os-cpu:latest
-  - docker run -d --ipc=host -p 9091:6274 --name=mapd mapd/core-os-cpu:latest
+  - docker run -d --ipc=host -p 6274:6274 --name=mapd mapd/core-os-cpu:latest
   - docker ps -a
   - export PATH="$HOME/miniconda3/bin:$PATH"
 install:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -9,7 +9,7 @@ Usage
 
 .. note::
 
-   This assumes you have an OmniSci server running on ``localhost:9091`` with the
+   This assumes you have an OmniSci server running on ``localhost:6274`` with the
    default logins and databases, and have loaded the example "flights_2008_10k"
    dataset.
 
@@ -24,15 +24,15 @@ Create a :class:`Connection` with
    >>> con = connect(user="mapd", password="HyperInteractive", host="localhost",
    ...               dbname="mapd")
    >>> con
-   Connection(mapd://mapd:***@localhost:9091/mapd?protocol=binary)
+   Connection(mapd://mapd:***@localhost:6274/mapd?protocol=binary)
 
 or by passing in a connection string
 
 .. code-block:: python
 
-   >>> uri = "mapd://mapd:HyperInteractive@localhost:9091/mapd?protocol=binary"
+   >>> uri = "mapd://mapd:HyperInteractive@localhost:6274/mapd?protocol=binary"
    >>> con = connect(uri=uri)
-   Connection(mapd://mapd:***@localhost:9091/mapd?protocol=binary)
+   Connection(mapd://mapd:***@localhost:6274/mapd?protocol=binary)
 
 See the `SQLAlchemy`_ documentation on what makes up a connection string. The
 components are::

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -37,7 +37,7 @@ def connect(uri=None,           # type: Optional[str]
             user=None,          # type: Optional[str]
             password=None,      # type: Optional[str]
             host=None,          # type: Optional[str]
-            port=9091,          # type: Optional[int]
+            port=6274,          # type: Optional[int]
             dbname=None,        # type: Optional[str]
             protocol='binary',  # type: Optional[str]
             ):
@@ -63,12 +63,12 @@ def connect(uri=None,           # type: Optional[str]
     --------
     You can either pass a string ``uri`` or all the individual components
 
-    >>> connect('mapd://mapd:HyperInteractive@localhost:9091/mapd?'
+    >>> connect('mapd://mapd:HyperInteractive@localhost:6274/mapd?'
     ...         'protocol=binary')
-    Connection(mapd://mapd:***@localhost:9091/mapd?protocol=binary)
+    Connection(mapd://mapd:***@localhost:6274/mapd?protocol=binary)
 
     >>> connect(user='mapd', password='HyperInteractive', host='localhost',
-    ...         port=9091, dbname='mapd')
+    ...         port=6274, dbname='mapd')
 
     """
     return Connection(uri=uri, user=user, password=password, host=host,
@@ -119,7 +119,7 @@ class Connection:
                  user=None,          # type: Optional[str]
                  password=None,      # type: Optional[str]
                  host=None,          # type: Optional[str]
-                 port=9091,          # type: Optional[int]
+                 port=6274,          # type: Optional[int]
                  dbname=None,        # type: Optional[str]
                  protocol='binary',  # type: Optional[str]
                  ):
@@ -128,7 +128,7 @@ class Connection:
             if not all([user is None,
                         password is None,
                         host is None,
-                        port == 9091,
+                        port == 6274,
                         dbname is None,
                         protocol == 'binary']):
                 raise TypeError("Cannot specify both URI and other arguments")

--- a/scripts/generate_thrift_structs.py
+++ b/scripts/generate_thrift_structs.py
@@ -1,6 +1,6 @@
 """
 This script generates the thrift structures used for unit testing pymapd.
-It requires an OmniSci server to be running on localhost:9091 with the default
+It requires an OmniSci server to be running on localhost:6274 with the default
 username, password, and database name.
 
 .. code-block:: console
@@ -44,7 +44,7 @@ def main():
     user_name = 'mapd'
     passwd = 'HyperInteractive'
     hostname = 'localhost'
-    portno = 9091
+    portno = 6274
 
     client = get_client(hostname, portno)
     session = client.connect(user_name, passwd, db_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from pymapd import connect
 ttypes = importlib.import_module("mapd.ttypes")
 HERE = os.path.dirname(__file__)
 
-socket = TSocket.TSocket("localhost", 9091)
+socket = TSocket.TSocket("localhost", 6274)
 transport = TTransport.TBufferedTransport(socket)
 
 
@@ -40,7 +40,7 @@ def mapd_server():
         subprocess.check_output(['docker', 'run', '-d',
                                  '--ipc=host',
                                  '-v', '/dev:/dev',
-                                 '-p', '9091:9091',
+                                 '-p', '6274:6274',
                                  '-p', '9092:9092',
                                  '--name=mapd', 'mapd/core-os-cpu:latest'])
         # yield and stop afterwards?
@@ -53,7 +53,7 @@ def mapd_server():
 @pytest.fixture(scope='session')
 def con(mapd_server):
     return connect(user="mapd", password='HyperInteractive', host='localhost',
-                   port=9091, protocol='binary', dbname='mapd')
+                   port=6274, protocol='binary', dbname='mapd')
 
 
 def _load_pickle(filepath):

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -57,15 +57,15 @@ class TestConnect:
 class TestURI:
 
     def test_parse_uri(self):
-        uri = ('mapd://mapd:HyperInteractive@localhost:9091/mapd?'
+        uri = ('mapd://mapd:HyperInteractive@localhost:6274/mapd?'
                'protocol=binary')
         result = _parse_uri(uri)
         expected = ConnectionInfo("mapd", "HyperInteractive", "localhost",
-                                  9091, "mapd", "binary")
+                                  6274, "mapd", "binary")
         assert result == expected
 
     def test_both_raises(self):
-        uri = ('mapd://mapd:HyperInteractive@localhost:9091/mapd?'
+        uri = ('mapd://mapd:HyperInteractive@localhost:6274/mapd?'
                'protocol=binary')
         with pytest.raises(TypeError):
             connect(uri=uri, user='my user')

--- a/tests/test_deallocate.py
+++ b/tests/test_deallocate.py
@@ -24,7 +24,7 @@ class TestDeallocate:
         return connect(user="mapd",
                        password='HyperInteractive',
                        host='localhost',
-                       port=9091, protocol='binary', dbname='mapd')
+                       port=6274, protocol='binary', dbname='mapd')
 
     def _transact(self, con):
         drop = 'drop table if exists iris;'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,24 +34,24 @@ class TestIntegration:
         'binary'])
     def test_connect(self, protocol):
         con = connect(user="mapd", password='HyperInteractive',
-                      host='localhost', port=9091, protocol=protocol,
+                      host='localhost', port=6274, protocol=protocol,
                       dbname='mapd')
         assert con is not None
         assert protocol in repr(con)
 
     def test_connect_uri(self):
-        uri = ('mapd://mapd:HyperInteractive@localhost:9091/mapd?protocol='
+        uri = ('mapd://mapd:HyperInteractive@localhost:6274/mapd?protocol='
                'binary')
         con = connect(uri=uri)
         assert con._user == 'mapd'
         assert con._password == 'HyperInteractive'
         assert con._host == 'localhost'
-        assert con._port == 9091
+        assert con._port == 6274
         assert con._dbname == 'mapd'
         assert con._protocol == 'binary'
 
     def test_connect_uri_and_others_raises(self):
-        uri = ('mapd://mapd:HyperInteractive@localhost:9091/mapd?protocol='
+        uri = ('mapd://mapd:HyperInteractive@localhost:6274/mapd?protocol='
                'binary')
         with pytest.raises(TypeError):
             connect(username='mapd', uri=uri)


### PR DESCRIPTION
Switch references to 9091 to 6274 to support the port remapping for 4.5. Fixes #163 