### PR TITLE
Remove ability to return result rowwise

### DIFF
--- a/pymapd/_parsers.py
+++ b/pymapd/_parsers.py
@@ -48,22 +48,6 @@ _thrift_encodings_to_values = T.TEncodingType._NAMES_TO_VALUES
 _thrift_values_to_encodings = T.TEncodingType._VALUES_TO_NAMES
 
 
-def _extract_row_val(desc, val):
-    # type: (T.TColumnType, T.TDatum) -> Any
-    typename = T.TDatumType._VALUES_TO_NAMES[desc.col_type.type]
-    if val.is_null:
-        return None
-    val = getattr(val.val, _typeattr[typename] + '_val')
-    if typename == 'TIMESTAMP':
-        val = datetime_in_precisions(val, desc.col_type.precision)
-    elif typename == 'DATE':
-        base = datetime.datetime(1970, 1, 1)
-        val = (base + datetime.timedelta(seconds=val)).date()
-    elif typename == 'TIME':
-        val = seconds_to_time(val)
-    return val
-
-
 def _extract_col_vals(desc, val):
     # type: (T.TColumnType, T.TColumn) -> Any
     typename = T.TDatumType._VALUES_TO_NAMES[desc.col_type.type]
@@ -110,11 +94,6 @@ def _extract_column_details(row_desc):
                       _thrift_values_to_encodings[x.col_type.encoding])
         for x in row_desc
     ]
-
-
-def _is_columnar(data):
-    # type: (T.TQueryResult) -> bool
-    return data.row_set.is_columnar
 
 
 def _load_schema(buf):

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -123,13 +123,12 @@ class Cursor:
         except T.TMapDException as e:
             raise _translate_exception(e) from e
         self._description = _extract_description(result.row_set.row_desc)
-        if self.columnar:
-            try:
-                self.rowcount = len(result.row_set.columns[0].nulls)
-            except IndexError:
-                pass
-        else:
-            self.rowcount = len(result.row_set.rows)
+
+        try:
+            self.rowcount = len(result.row_set.columns[0].nulls)
+        except IndexError:
+            pass
+
         self._result_set = make_row_results_set(result)
         self._result = result
         return self

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -2,18 +2,20 @@ import mapd.ttypes as T
 from typing import Any, Optional, List, Iterator, Union, Tuple, Iterable
 
 from .exceptions import _translate_exception
-from ._parsers import (_extract_col_vals, _extract_description,
-                       _extract_row_val, _is_columnar, _bind_parameters)
+from ._parsers import (_extract_col_vals,
+                       _extract_description,
+                       _bind_parameters
+                       )
 
 
 class Cursor:
     """A database cursor."""
 
-    def __init__(self, connection, columnar=True):
+    def __init__(self, connection):
         # type: (Any, bool) -> None
         # XXX: supposed to share state between cursors of the same connection
         self.connection = connection
-        self.columnar = columnar
+        self.columnar = True
         self.rowcount = -1
         self._description = None  # type: Optional[List[str]]
         self._arraysize = 1
@@ -195,16 +197,12 @@ def make_row_results_set(data):
     -------
     results : Iterator[tuple]
     """
-    if _is_columnar(data):
-        if data.row_set.columns:
-            nrows = len(data.row_set.columns[0].nulls)
-            ncols = len(data.row_set.row_desc)
-            columns = [_extract_col_vals(desc, col)
-                       for desc, col in zip(data.row_set.row_desc,
-                                            data.row_set.columns)]
-            for i in range(nrows):
-                yield tuple(columns[j][i] for j in range(ncols))
-    else:
-        for row in data.row_set.rows:
-            yield tuple(_extract_row_val(desc, val)
-                        for desc, val in zip(data.row_set.row_desc, row.cols))
+
+    if data.row_set.columns:
+        nrows = len(data.row_set.columns[0].nulls)
+        ncols = len(data.row_set.row_desc)
+        columns = [_extract_col_vals(desc, col)
+                   for desc, col in zip(data.row_set.row_desc,
+                                        data.row_set.columns)]
+        for i in range(nrows):
+            yield tuple(columns[j][i] for j in range(ncols))

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -15,7 +15,6 @@ class Cursor:
         # type: (Any, bool) -> None
         # XXX: supposed to share state between cursors of the same connection
         self.connection = connection
-        self.columnar = True
         self.rowcount = -1
         self._description = None  # type: Optional[List[str]]
         self._arraysize = 1
@@ -118,7 +117,7 @@ class Cursor:
         try:
             result = self.connection._client.sql_execute(
                 self.connection._session, operation,
-                column_format=self.columnar,
+                column_format=True,
                 nonce=None, first_n=-1, at_most_n=-1)
         except T.TMapDException as e:
             raise _translate_exception(e) from e

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -187,10 +187,8 @@ class TestIntegration:
         expected = [('RHAT', 100), ('GOOG', 100)]
         assert result == expected
 
-    @pytest.mark.parametrize('columnar', [True, False])
-    def test_select_dates(self, columnar, con, date_table):
+    def test_select_dates(self, con, date_table):
         c = con.cursor()
-        c.columnar = columnar
         result = list(c.execute("select * from {}".format(date_table)))
         expected = [
             (datetime.date(2006, 1, 5),
@@ -338,7 +336,6 @@ class TestLoaders:
                     'date_'])
         con.load_table_columnar(all_types_table, data, preserve_index=False)
         c = con.cursor()
-        c.columnar = False
         result = list(c.execute("select * from all_types"))
         expected = [(1, 0, 0, 0, 0.0, 0.0, 'a', 'a',
                     datetime.time(0, 11, 59),
@@ -385,12 +382,6 @@ class TestLoaders:
         # the test
 
         c = con.cursor()
-        result = c.execute("select * from pymapd_test_table")
-        expected = [(1,), (None,)]
-        assert result.fetchall() == expected
-
-        c = con.cursor()
-        c.columnar = False
         result = c.execute("select * from pymapd_test_table")
         expected = [(1,), (None,)]
         assert result.fetchall() == expected

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -161,13 +161,6 @@ class TestIntegration:
         result = con.select_ipc_gpu("select * from stocks", first_n=1)
         assert len(result) == 1
 
-    def test_select_rowwise(self, con, stocks):
-        c = con.cursor()
-        c.columnar = False
-        c.execute("select * from stocks;")
-        assert c.rowcount == 2
-        assert c.description is not None
-
     def test_fetchone(self, con, stocks):
         c = con.cursor()
         c.execute("select symbol, qty from stocks")

--- a/tests/test_results_set.py
+++ b/tests/test_results_set.py
@@ -4,16 +4,6 @@ from pymapd.cursor import make_row_results_set
 
 class TestRowResults:
 
-    def test_basic(self, rowwise):
-        result = list(make_row_results_set(rowwise))
-        expected = [
-            ('2006-01-05', 'BUY', 'RHAT', 100, 35.13999938964844,
-             1.100000023841858, datetime.datetime(2010, 1, 1, 12, 1, 1)),
-            ('2006-01-05', 'BUY', 'GOOG', 100, 12.140000343322754,
-             1.2000000476837158, datetime.datetime(2010, 1, 1, 12, 2, 2))
-        ]
-        assert result == expected
-
     def test_basic_colwise(self, colwise):
         expected = [
             ('2006-01-05', 'BUY', 'RHAT', 100, 35.13999938964844,
@@ -69,51 +59,6 @@ class TestRowResults:
                 TColumn(data=TColumnData(int_col=[-2147483648]), nulls=[True]),
             ],
             is_columnar=True))
-
-        result = list(make_row_results_set(rs))
-        assert result == [(None,) * 11]
-
-        # row-wise
-        rs = TQueryResult(TRowSet(
-            row_desc=[
-                TColumnType(col_name='a',
-                            col_type=TTypeInfo(type=0, nullable=True)),
-                TColumnType(col_name='b',
-                            col_type=TTypeInfo(type=1, nullable=True)),
-                TColumnType(col_name='c',
-                            col_type=TTypeInfo(type=2, nullable=True)),
-                TColumnType(col_name='d',
-                            col_type=TTypeInfo(type=3, nullable=True)),
-                TColumnType(col_name='e',
-                            col_type=TTypeInfo(type=4, nullable=True)),
-                TColumnType(col_name='f',
-                            col_type=TTypeInfo(type=5, nullable=True)),
-                TColumnType(col_name='g',
-                            col_type=TTypeInfo(type=6, nullable=True)),
-                TColumnType(col_name='h',
-                            col_type=TTypeInfo(type=7, nullable=True)),
-                TColumnType(col_name='i',
-                            col_type=TTypeInfo(type=8, nullable=True)),
-                TColumnType(col_name='j',
-                            col_type=TTypeInfo(type=9, nullable=True)),
-                TColumnType(col_name='k',
-                            col_type=TTypeInfo(type=10, nullable=True)),
-            ],
-            rows=[TRow(cols=[
-                TDatum(val=TDatumVal(int_val=-1), is_null=True),
-                TDatum(val=TDatumVal(int_val=-1), is_null=True),
-                TDatum(val=TDatumVal(int_val=-1), is_null=True),
-                TDatum(val=TDatumVal(real_val=-1), is_null=True),
-                TDatum(val=TDatumVal(real_val=-1), is_null=True),
-                TDatum(val=TDatumVal(real_val=-1), is_null=True),
-                TDatum(val=TDatumVal(str_val=-1), is_null=True),
-                TDatum(val=TDatumVal(int_val=-1), is_null=True),
-                TDatum(val=TDatumVal(int_val=-1), is_null=True),
-                TDatum(val=TDatumVal(int_val=-1), is_null=True),
-                TDatum(val=TDatumVal(int_val=-1), is_null=True),
-            ])
-            ],
-            is_columnar=False))
 
         result = list(make_row_results_set(rs))
         assert result == [(None,) * 11]


### PR DESCRIPTION
Fixes #180 

Idea behind this PR is that returning results row-wise adds complexity for little benefit. OmniSci itself doesn't really provide cursoring. Returning results row-wise is a slower process, but ultimately the return value of a list of tuples from `sql_execute` gets you the same functional result.

It's my assertion that no one in the wild will have changed the default of `columnar=True` on the cursor, as using an explicit cursor itself should be somewhat uncommon.