### PR TITLE
Tighten lower bounds of packages

### DIFF
--- a/ci/install-travis.sh
+++ b/ci/install-travis.sh
@@ -28,9 +28,9 @@ conda create -n omnisci-dev python=${PYTHON} \
 thrift=0.11.0 \
 numpydoc \
 "pyarrow>=0.10.0,<0.13" \
-sqlalchemy \
-numpy>=1.14 \
-pandas \
+sqlalchemy>=1.3 \
+numpy>=1.16 \
+pandas>=0.24 \
 coverage \
 flake8 \
 pytest \

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,10 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-install_requires = ['thrift == 0.11.0', 'sqlalchemy', 'numpy', 'pandas',
+install_requires = ['thrift == 0.11.0',
+                    'sqlalchemy >= 1.3',
+                    'numpy >= 1.16',
+                    'pandas >= 0.24',
                     'pyarrow >= 0.10.0,<0.13']
 
 # Optional Requirements


### PR DESCRIPTION
Fixes #179. Currently have pymapd master, cudf 0.5 and Ibis 0.14 installed in the same conda environment with these settings