### PR TITLE
Make DATEs consistent with respect to changes in Omnisci Core

### DIFF
--- a/pymapd/_pandas_loaders.py
+++ b/pymapd/_pandas_loaders.py
@@ -17,7 +17,7 @@ from mapd.ttypes import (
 )
 from ._utils import (
     date_to_seconds, time_to_seconds, datetime_to_seconds,
-    mapd_to_na, mapd_to_slot, date_to_days
+    mapd_to_na, mapd_to_slot
 )
 
 
@@ -77,7 +77,7 @@ def get_mapd_type_from_object(data):
         raise TypeError("Unhandled type {}".format(data.dtype))
 
 
-def thrift_cast(data, mapd_type, scale=0, type_encoding=""):
+def thrift_cast(data, mapd_type, scale=0):
     """Cast data type to the expected thrift types"""
 
     if mapd_type == 'TIMESTAMP':
@@ -85,8 +85,7 @@ def thrift_cast(data, mapd_type, scale=0, type_encoding=""):
     elif mapd_type == 'TIME':
         return pd.Series(time_to_seconds(x) for x in data)
     elif mapd_type == 'DATE':
-        data = date_to_days(data) if type_encoding == "DATE_IN_DAYS" \
-            else date_to_seconds(data)
+        data = date_to_seconds(data)
         data = data.fillna(mapd_to_na[mapd_type])
         return data.astype(int)
     elif mapd_type == 'BOOL':
@@ -134,7 +133,7 @@ def build_input_columnar(df, preserve_index=True,
 
             if mapd_type in {'TIME', 'TIMESTAMP', 'DATE', 'BOOL'}:
                 # requires a cast to integer
-                data = thrift_cast(data, mapd_type, 0, col_types[colindex][2])
+                data = thrift_cast(data, mapd_type, 0)
 
             if mapd_type in ['DECIMAL']:
                 # requires a calculation be done using the scale

--- a/pymapd/_utils.py
+++ b/pymapd/_utils.py
@@ -62,12 +62,6 @@ def date_to_seconds(arr):
     return arr.apply(lambda x: np.datetime64(x, "s").astype(int))
 
 
-def date_to_days(arr):
-    """Converts date into days"""
-
-    return arr.apply(lambda x: np.datetime64(x, "D").astype(int))
-
-
 mapd_to_slot = {
     'BOOL': 'int_col',
     'BOOLEAN': 'int_col',

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -561,6 +561,11 @@ class Connection:
         load_table
         load_table_arrow
         load_table_rowwise
+
+        Note
+        ----
+        Use ``pymapd >= 0.11.0`` while running with ``omnisci >= 4.6.0`` in
+        order to avoid loading inconsistent values into DATE column.
         """
 
         if isinstance(data, pd.DataFrame):

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -578,7 +578,7 @@ class Connection:
                 col_names_from_schema \
                 else list(data)
 
-            col_types = [(i[1], i[4], i[6]) for i in table_details]
+            col_types = [(i[1], i[4]) for i in table_details]
 
             input_cols = _pandas_loaders.build_input_columnar(
                 data,


### PR DESCRIPTION
With the introduction of the new encoder, we would expect them to be in days, hence reverting the changes made earlier on the client side.

fixes #177 

**Note**: Current `load_table_columnar` test will fail since it is tagged to docker image of the previous release, we should get this in with sync to the new core release (4.6.0)