### PR TITLE
Remove erroneous int8 cast code and fix mutating df

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,6 +12,7 @@ from pymapd.cursor import Cursor
 from pymapd._parsers import Description, ColumnDetails
 from mapd.ttypes import TMapDException
 import pandas as pd
+from pandas.api.types import is_object_dtype, is_categorical_dtype
 
 from .utils import no_gpu
 
@@ -544,3 +545,9 @@ class TestLoaders:
         res["A"] = res["A"].astype('category')
         res["B"] = res["B"].astype('category')
         assert pd.DataFrame.equals(df_ipc, res)
+
+        # test that input df wasn't mutated
+        # original input is object, categorical
+        # to load via Arrow, converted internally to object, object
+        assert is_object_dtype(df["A"])
+        assert is_categorical_dtype(df["B"])


### PR DESCRIPTION
Fixes #169. Removes unnecessary cast to int16 for int8 columns, allowing for data upload using `load_table`. 

Also removes mutating the dataframe as part of upload; removing the int8 cast code removes one issue with mutating the dataframe. Per PR #189, categorical also mutates dataframe, since OmniSci wants a text column not an Arrow Dict type. Fix tests whether a categorical column(s) exists, and if so, makes a copy before mutating the copy to the proper data format. Otherwise, no copy of original data is made, keeping performance as best as possible.

Ideally, OmniSci would accept the Arrow Dict type internally to avoid this copy/cast (cc: @andrewseidl ) 