### PR TITLE
Add some roundtrip CPU tests for non-null data

### DIFF
--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -495,7 +495,7 @@ class Connection:
         if isinstance(data, pd.DataFrame):
             # We need to convert a Pandas dataframe to a list of tuples before
             # loading row wise
-            data = list(data.itertuples(index=False, name=None))
+            data = data.itertuples(index=preserve_index, name=None)
 
         input_data = _build_input_rows(data)
         self._client.load_table(self._session, table_name, input_data)

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -493,9 +493,9 @@ class Connection:
                             .format(method))
 
         if isinstance(data, pd.DataFrame):
-            # We need to convert a Pandas dataframe to an array before we
-            # can load row wise
-            data = data.values
+            # We need to convert a Pandas dataframe to a list of tuples before
+            # loading row wise
+            data = list(data.itertuples(index=False, name=None))
 
         input_data = _build_input_rows(data)
         self._client.load_table(self._session, table_name, input_data)

--- a/tests/test_data_no_nulls_cpu.py
+++ b/tests/test_data_no_nulls_cpu.py
@@ -1,3 +1,9 @@
+"""
+The intent of this file is to be a full integration test. Whenever possible,
+add a datatype to the main _tests_table_no_nulls function, so that the tests
+will evaluate not only that a data type works, but that it works in the
+presence of the other data types as well in the same dataframe/database table
+"""
 import pytest
 import pandas as pd
 import numpy as np

--- a/tests/test_data_no_nulls_cpu.py
+++ b/tests/test_data_no_nulls_cpu.py
@@ -1,0 +1,65 @@
+import pytest
+import pandas as pd
+import numpy as np
+
+
+def _tests_table_no_nulls(n_samples):
+
+    tinyint_ = np.random.randint(low=-127, high=127,
+                                 size=n_samples, dtype='int8')
+
+    smallint_ = np.random.randint(low=-32767, high=32767,
+                                  size=n_samples, dtype='int16')
+
+    int_ = np.random.randint(low=-2147483647, high=2147483647,
+                             size=n_samples, dtype='int32')
+
+    bigint_ = np.random.randint(low=-9223372036854775807,
+                                high=9223372036854775807,
+                                size=n_samples,
+                                dtype='int64')
+
+    d = {'tinyint_': tinyint_,
+         'smallint_': smallint_,
+         'int_': int_,
+         'bigint_': bigint_
+         }
+
+    return pd.DataFrame(d)
+
+
+@pytest.mark.usefixtures("mapd_server")
+class TestDataNoNulls:
+
+    @pytest.mark.parametrize('method', ["rows", "columnar", "arrow", "infer"])
+    def test_create_load_table_no_nulls(self, con, method):
+
+        df_in = _tests_table_no_nulls(10000)
+        con.execute("drop table if exists test_data_no_nulls;")
+        con.load_table("test_data_no_nulls", df_in, method=method)
+
+        # read_sql() uses execute() under the hood
+        df_out = pd.read_sql("select * from test_data_no_nulls", con)
+
+        # test size and table definition
+        assert df_in.shape == df_out.shape
+        gtd = con.get_table_details("test_data_no_nulls")
+        name_types = [(x.name, x.type) for x in gtd]
+        assert name_types == [('tinyint_', 'TINYINT'),
+                              ('smallint_', 'SMALLINT'),
+                              ('int_', 'INT'),
+                              ('bigint_', 'BIGINT')]
+
+        # pymapd won't necessarily return exact dtype as input using execute()
+        # and pd.read_sql() since transport is rows of tuples
+        # test that results are functionally the same
+        assert df_in["tinyint_"].sum() == df_out["tinyint_"].sum()
+        assert df_in["smallint_"].sum() == df_out["smallint_"].sum()
+        assert df_in["int_"].sum() == df_out["int_"].sum()
+        assert df_in["bigint_"].sum() == df_out["bigint_"].sum()
+
+        # select_ipc uses Arrow, so expect exact df back
+        df_out_arrow = con.select_ipc("select * from test_data_no_nulls")
+        assert pd.DataFrame.equals(df_in, df_out_arrow)
+
+        con.execute("drop table if exists test_data_no_nulls;")

--- a/tests/test_data_no_nulls_cpu.py
+++ b/tests/test_data_no_nulls_cpu.py
@@ -5,24 +5,32 @@ import numpy as np
 
 def _tests_table_no_nulls(n_samples):
 
-    tinyint_ = np.random.randint(low=-127, high=127,
-                                 size=n_samples, dtype='int8')
+    np.random.seed(12345)
 
-    smallint_ = np.random.randint(low=-32767, high=32767,
-                                  size=n_samples, dtype='int16')
+    tinyint_ = np.random.randint(low=-127, high=127, size=n_samples,
+                                 dtype='int8')
 
-    int_ = np.random.randint(low=-2147483647, high=2147483647,
-                             size=n_samples, dtype='int32')
+    smallint_ = np.random.randint(low=-32767, high=32767, size=n_samples,
+                                  dtype='int16')
+
+    int_ = np.random.randint(low=-2147483647, high=2147483647, size=n_samples,
+                             dtype='int32')
 
     bigint_ = np.random.randint(low=-9223372036854775807,
                                 high=9223372036854775807,
                                 size=n_samples,
                                 dtype='int64')
 
+    float_ = np.linspace(-3.4e37, 3.4e37, n_samples, dtype='float32')
+
+    double_ = np.linspace(-1.79e307, 1.79e307, n_samples, dtype='float64')
+
     d = {'tinyint_': tinyint_,
          'smallint_': smallint_,
          'int_': int_,
-         'bigint_': bigint_
+         'bigint_': bigint_,
+         'float_': float_,
+         'double_': double_
          }
 
     return pd.DataFrame(d)
@@ -48,18 +56,45 @@ class TestDataNoNulls:
         assert name_types == [('tinyint_', 'TINYINT'),
                               ('smallint_', 'SMALLINT'),
                               ('int_', 'INT'),
-                              ('bigint_', 'BIGINT')]
+                              ('bigint_', 'BIGINT'),
+                              ('float_', 'FLOAT'),
+                              ('double_', 'DOUBLE'),
+                              ]
+
+        # sort tables to ensure data in same order before compare
+        # need to sort by all the columns in case of ties
+        df_in.sort_values(by=['tinyint_',
+                              'smallint_',
+                              'int_',
+                              'bigint_'], inplace=True)
+        df_in.reset_index(drop=True, inplace=True)
+
+        df_out.sort_values(by=['tinyint_',
+                               'smallint_',
+                               'int_',
+                               'bigint_'], inplace=True)
+        df_out.reset_index(drop=True, inplace=True)
 
         # pymapd won't necessarily return exact dtype as input using execute()
         # and pd.read_sql() since transport is rows of tuples
-        # test that results are functionally the same
-        assert df_in["tinyint_"].sum() == df_out["tinyint_"].sum()
-        assert df_in["smallint_"].sum() == df_out["smallint_"].sum()
-        assert df_in["int_"].sum() == df_out["int_"].sum()
-        assert df_in["bigint_"].sum() == df_out["bigint_"].sum()
+        # test that results arethe same when dtypes aligned
+        assert pd.DataFrame.equals(df_in["tinyint_"],
+                                   df_out["tinyint_"].astype('int8'))
+        assert pd.DataFrame.equals(df_in["smallint_"],
+                                   df_out["smallint_"].astype('int16'))
+        assert pd.DataFrame.equals(df_in["int_"],
+                                   df_out["int_"].astype('int32'))
+        assert pd.DataFrame.equals(df_in["bigint_"], df_out["bigint_"])
+        assert all(np.isclose(df_in["float_"], df_out["float_"]))
+        assert all(np.isclose(df_in["double_"], df_out["double_"]))
 
-        # select_ipc uses Arrow, so expect exact df back
+        # select_ipc uses Arrow, so expect exact df dtypes back
         df_out_arrow = con.select_ipc("select * from test_data_no_nulls")
+        df_out_arrow.sort_values(by=['tinyint_',
+                                     'smallint_',
+                                     'int_',
+                                     'bigint_'], inplace=True)
+        df_out_arrow.reset_index(drop=True, inplace=True)
         assert pd.DataFrame.equals(df_in, df_out_arrow)
 
         con.execute("drop table if exists test_data_no_nulls;")

--- a/tests/test_data_no_nulls_cpu.py
+++ b/tests/test_data_no_nulls_cpu.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 import numpy as np
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 
 def _tests_table_no_nulls(n_samples):
@@ -34,6 +34,9 @@ def _tests_table_no_nulls(n_samples):
     date_ = [date(1970, 1, 1) + timedelta(days=int(x))
              for x in np.random.randint(-24000, 24000, size=n_samples)]
 
+    datetime_ = [datetime(1970, 1, 1) + timedelta(days=int(x), minutes=int(x))
+                 for x in np.random.randint(-24000, 24000, size=10000)]
+
     d = {'tinyint_': tinyint_,
          'smallint_': smallint_,
          'int_': int_,
@@ -41,7 +44,8 @@ def _tests_table_no_nulls(n_samples):
          'float_': float_,
          'double_': double_,
          'bool_': bool_,
-         'date_': date_
+         'date_': date_,
+         'datetime_': datetime_
          }
 
     return pd.DataFrame(d)
@@ -72,6 +76,7 @@ class TestDataNoNulls:
                               ('double_', 'DOUBLE'),
                               ('bool_', 'BOOL'),
                               ('date_', 'DATE'),
+                              ('datetime_', 'TIMESTAMP'),
                               ]
 
         # sort tables to ensure data in same order before compare
@@ -110,6 +115,8 @@ class TestDataNoNulls:
 
         assert pd.DataFrame.equals(df_in["date_"], df_out["date_"])
 
+        assert pd.DataFrame.equals(df_in["datetime_"], df_out["datetime_"])
+
         con.execute("drop table if exists test_data_no_nulls;")
 
     @pytest.mark.parametrize('method', ["rows", "columnar", "arrow", "infer"])
@@ -130,7 +137,8 @@ class TestDataNoNulls:
                                 bigint_,
                                 float_,
                                 double_,
-                                date_
+                                date_,
+                                datetime_
                                 from test_data_no_nulls_ipc""")
 
         # test size and table definition

--- a/tests/test_data_no_nulls_cpu.py
+++ b/tests/test_data_no_nulls_cpu.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 import numpy as np
-from datetime import date, datetime, timedelta
+from datetime import date, time, datetime, timedelta
 
 
 def _tests_table_no_nulls(n_samples):
@@ -37,6 +37,12 @@ def _tests_table_no_nulls(n_samples):
     datetime_ = [datetime(1970, 1, 1) + timedelta(days=int(x), minutes=int(x))
                  for x in np.random.randint(-24000, 24000, size=10000)]
 
+    time_h = np.random.randint(0, 24, size=10000)
+    time_m = np.random.randint(0, 60, size=10000)
+    time_s = np.random.randint(0, 60, size=10000)
+
+    time_ = [time(h, m, s) for h, m, s in zip(time_h, time_m, time_s)]
+
     d = {'tinyint_': tinyint_,
          'smallint_': smallint_,
          'int_': int_,
@@ -45,7 +51,8 @@ def _tests_table_no_nulls(n_samples):
          'double_': double_,
          'bool_': bool_,
          'date_': date_,
-         'datetime_': datetime_
+         'datetime_': datetime_,
+         'time_': time_
          }
 
     return pd.DataFrame(d)
@@ -77,6 +84,7 @@ class TestDataNoNulls:
                               ('bool_', 'BOOL'),
                               ('date_', 'DATE'),
                               ('datetime_', 'TIMESTAMP'),
+                              ('time_', 'TIME'),
                               ]
 
         # sort tables to ensure data in same order before compare
@@ -117,6 +125,8 @@ class TestDataNoNulls:
 
         assert pd.DataFrame.equals(df_in["datetime_"], df_out["datetime_"])
 
+        assert pd.DataFrame.equals(df_in["time_"], df_out["time_"])
+
         con.execute("drop table if exists test_data_no_nulls;")
 
     @pytest.mark.parametrize('method', ["rows", "columnar", "arrow", "infer"])
@@ -138,7 +148,8 @@ class TestDataNoNulls:
                                 float_,
                                 double_,
                                 date_,
-                                datetime_
+                                datetime_,
+                                time_
                                 from test_data_no_nulls_ipc""")
 
         # test size and table definition


### PR DESCRIPTION
Work towards #191 

`load_table`: {rows, column, arrow, infer}
`sql_execute` and `select_ipc`