### PR TITLE
Remove python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
   matrix:
     - PYTHON=3.7
     - PYTHON=3.6
-    - PYTHON=3.5
 before_install:
   - docker pull mapd/core-os-cpu:latest
   - docker run -d --ipc=host -p 6278:6278 -p 6274:6274 --name=mapd mapd/core-os-cpu:latest

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
 
     license='Apache Software License',
 
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -52,7 +52,6 @@ setup(
         'Topic :: Scientific/Engineering',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3 :: Only',


### PR DESCRIPTION
Because of use of f-strings, can no longer use python 3.5. This also brings us in line with conda in only supporting the last two releases of Python.

Fixes #206 