### PR TITLE
Swap itertuples for .values

### DIFF
--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -493,9 +493,9 @@ class Connection:
                             .format(method))
 
         if isinstance(data, pd.DataFrame):
-            # We need to convert a Pandas dataframe to an array before we
-            # can load row wise
-            data = data.values
+            # We need to convert a Pandas dataframe to a list of tuples before
+            # loading row wise
+            data = list(data.itertuples(index=False, name=None))
 
         input_data = _build_input_rows(data)
         self._client.load_table(self._session, table_name, input_data)


### PR DESCRIPTION
Calling .values on a dataframe creates an array, promoted to the common datatype able to hold all the data. This can cause ints to be converted to float and other undesirable behavior.

Intent is just to move from dataframe to an iterable, which itertuples does without changing data representation in a cell