### PR TITLE
Throw exception if version number <4.6

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -6,6 +6,7 @@ from pymapd.connection import _parse_uri, ConnectionInfo
 from pymapd._parsers import ColumnDetails, _extract_column_details
 
 
+@pytest.mark.usefixtures("mapd_server")
 class TestConnect:
 
     def test_host_specified(self):
@@ -16,33 +17,21 @@ class TestConnect:
         with pytest.raises(OperationalError):
             connect(host='localhost', protocol='binary', port=1234)
 
-    def test_close(self, mock_client):
-        con = connect(user='user', password='password',
-                      host='localhost', dbname='dbname')
-        assert con.closed == 0
-        con.close()
-        assert con.closed == 1
+    def test_close(self):
+        conn = connect(user='mapd', password='HyperInteractive',
+                       host='localhost', dbname='mapd')
+        assert conn.closed == 0
+        conn.close()
+        assert conn.closed == 1
 
-    def test_connect(self, mock_client):
-        con = connect(user='user', password='password',
-                      host='localhost', dbname='dbname')
-        assert mock_client.call_count == 1
-        assert con._client.connect.call_args == [
-            ('user', 'password', 'dbname')
-        ]
-
-    def test_context_manager(self, mock_client):
-        con = connect(user='user', password='password',
-                      host='localhost', dbname='dbname')
+    def test_context_manager(self, con):
         with con as cur:
             pass
 
         assert isinstance(cur, Cursor)
         assert con.closed == 0
 
-    def test_commit_noop(self, mock_client):
-        con = connect(user='user', password='password',
-                      host='localhost', dbname='dbname')
+    def test_commit_noop(self, con):
         result = con.commit()  # it worked
         assert result is None
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -16,17 +16,13 @@ def mock_connection(mock_client):
                    host='localhost', dbname='dbname')
 
 
+@pytest.mark.usefixtures("mapd_server")
 class TestCursor:
 
     def test_empty_iterable(self):
         c = Cursor(None)
         result = list(c)
         assert result == []
-
-    def test_context_manager(self, mock_connection):
-        c = mock_connection.cursor()
-        with c:
-            c.execute("select 1;")
 
     def test_escape_basic(self):
         query = "select * from foo where bar > :baz"

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -16,7 +16,6 @@ def mock_connection(mock_client):
                    host='localhost', dbname='dbname')
 
 
-@pytest.mark.usefixtures("mapd_server")
 class TestCursor:
 
     def test_empty_iterable(self):


### PR DESCRIPTION
With #188, we need to prevent users using OmniSci <=4.5 from using pymapd >= 0.11. This is because of the backend change to switch encoding of dates from epoch seconds to epoch days. It was determined by myself and JP that it's better to throw the error on login, rather than allow user to have a script blow up unexpectedly once using columnar load.