### PR TITLE
Remove legacy typing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
   - echo "script start"
   - source activate omnisci-dev
   - pytest tests
-  - flake8 --ignore=F401
+  - flake8

--- a/pymapd/_mutators.py
+++ b/pymapd/_mutators.py
@@ -4,7 +4,6 @@ Setter and Getter for TDataFrame
 
 
 def set_tdf(self, tdf):
-    # type: () -> None
     """Assigns a TDataFrame to cudf/pandas Dataframe
 
         Parameters

--- a/pymapd/_parsers.py
+++ b/pymapd/_parsers.py
@@ -12,7 +12,6 @@ from ._mutators import set_tdf, get_tdf
 from ._utils import seconds_to_time, datetime_in_precisions
 import numpy as np
 from .ipc import load_buffer, shmdt
-from typing import Any, List
 
 
 Description = namedtuple("Description", ["name", "type_code", "display_size",
@@ -69,7 +68,6 @@ def _format_result_time(arr):
 
 
 def _extract_col_vals(desc, val):
-    # type: (T.TColumnType, T.TColumn) -> Any
 
     typename = T.TDatumType._VALUES_TO_NAMES[desc.col_type.type]
     nulls = val.nulls
@@ -103,7 +101,6 @@ def _extract_col_vals(desc, val):
 
 
 def _extract_description(row_desc):
-    # type: (List[T.TColumnType]) -> List[Description]
     """
     Return a tuple of (name, type_code, display_size, internal_size,
                        precision, scale, null_ok)

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -6,8 +6,6 @@ import base64
 import pandas as pd
 import pyarrow as pa
 import ctypes
-from typing import Optional, Tuple
-
 from sqlalchemy.engine.url import make_url
 from thrift.protocol import TBinaryProtocol, TJSONProtocol
 from thrift.transport import TSocket, THttpClient, TTransport
@@ -35,15 +33,14 @@ ConnectionInfo = namedtuple("ConnectionInfo", ['user', 'password', 'host',
                                                'port', 'dbname', 'protocol'])
 
 
-def connect(uri=None,           # type: Optional[str]
-            user=None,          # type: Optional[str]
-            password=None,      # type: Optional[str]
-            host=None,          # type: Optional[str]
-            port=6274,          # type: Optional[int]
-            dbname=None,        # type: Optional[str]
-            protocol='binary',  # type: Optional[str]
+def connect(uri=None,
+            user=None,
+            password=None,
+            host=None,
+            port=6274,
+            dbname=None,
+            protocol='binary',
             ):
-    # type: (...) -> Connection
     """
     Crate a new Connection.
 
@@ -78,7 +75,6 @@ def connect(uri=None,           # type: Optional[str]
 
 
 def _parse_uri(uri):
-    # type: (str) -> ConnectionInfo
     """
     Parse connection string
 
@@ -117,15 +113,14 @@ class Connection:
     """Connect to your OmniSci database."""
 
     def __init__(self,
-                 uri=None,           # type: Optional[str]
-                 user=None,          # type: Optional[str]
-                 password=None,      # type: Optional[str]
-                 host=None,          # type: Optional[str]
-                 port=6274,          # type: Optional[int]
-                 dbname=None,        # type: Optional[str]
-                 protocol='binary',  # type: Optional[str]
+                 uri=None,
+                 user=None,
+                 password=None,
+                 host=None,
+                 port=6274,
+                 dbname=None,
+                 protocol='binary',
                  ):
-        # type: (...) -> None
         if uri is not None:
             if not all([user is None,
                         password is None,
@@ -186,14 +181,12 @@ class Connection:
                                "for more details.")
 
     def __repr__(self):
-        # type: () -> str
         tpl = ('Connection(mapd://{user}:***@{host}:{port}/{dbname}?protocol'
                '={protocol})')
         return tpl.format(user=self._user, host=self._host, port=self._port,
                           dbname=self._dbname, protocol=self._protocol)
 
     def __del__(self):
-        # type: () -> None
         self.close()
 
     def __enter__(self):
@@ -207,7 +200,6 @@ class Connection:
         return self._closed
 
     def close(self):
-        # type: () -> None
         """Disconnect from the database"""
         try:
             self._client.disconnect(self._session)
@@ -217,7 +209,6 @@ class Connection:
             self._closed = 1
 
     def commit(self):
-        # type: () -> None
         """This is a noop, as OmniSci does not provide transactions.
 
         Implementing to comply with the specification.
@@ -225,7 +216,6 @@ class Connection:
         return None
 
     def execute(self, operation, parameters=None):
-        # type: (str, Optional[Tuple]) -> Cursor
         """Execute a SQL statement
 
         Parameters
@@ -241,7 +231,6 @@ class Connection:
         return c.execute(operation.strip(), parameters=parameters)
 
     def cursor(self):
-        # type: () -> Cursor
         """Create a new :class:`Cursor` object attached to this connection."""
         return Cursor(self)
 
@@ -346,7 +335,6 @@ class Connection:
         return df
 
     def deallocate_ipc_gpu(self, df, device_id=0):
-        # type: () -> None
         """Deallocate a DataFrame using GPU memory.
 
         Parameters
@@ -364,7 +352,6 @@ class Connection:
         return result
 
     def deallocate_ipc(self, df, device_id=0):
-        # type: () -> None
         """Deallocate a DataFrame using CPU shared memory.
 
         Parameters

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -1,6 +1,4 @@
 import mapd.ttypes as T
-from typing import Any, Optional, List, Iterator, Union, Tuple, Iterable
-
 from .exceptions import _translate_exception
 from ._parsers import (_extract_col_vals,
                        _extract_description,
@@ -12,17 +10,15 @@ class Cursor:
     """A database cursor."""
 
     def __init__(self, connection):
-        # type: (Any, bool) -> None
         # XXX: supposed to share state between cursors of the same connection
         self.connection = connection
         self.rowcount = -1
-        self._description = None  # type: Optional[List[str]]
+        self._description = None
         self._arraysize = 1
         self._result = None
-        self._result_set = None  # type: Optional[Iterator[Any]]
+        self._result_set = None
 
     def __iter__(self):
-        # type: () -> Union[List, Iterator]
         if self.result_set is None:
             return iter([])
         return self.result_set
@@ -35,7 +31,6 @@ class Cursor:
 
     @property
     def description(self):
-        # type: () -> Optional[List[str]]
         """
         Read-only sequence describing columns of the result set.
         Each column is an instance of `Description` describing
@@ -54,12 +49,10 @@ class Cursor:
 
     @property
     def result_set(self):
-        # type: () -> Optional[Iterator]
         return self._result_set
 
     @property
     def arraysize(self):
-        # type: () -> int
         """The number of rows to fetch at a time with `fetchmany`. Default 1.
 
         See Also
@@ -70,7 +63,6 @@ class Cursor:
 
     @arraysize.setter
     def arraysize(self, value):
-        # type: (int) -> None
         """Number of items to fetch with :func:`fetchmany`."""
         if not isinstance(value, int):
             raise TypeError("Value must be an integer, got {} instead".format(
@@ -78,13 +70,11 @@ class Cursor:
         self._arraysize = value
 
     def close(self):
-        # type: () -> None
         """Close this cursor."""
         # TODO
         pass
 
     def execute(self, operation, parameters=None):
-        # type: (str, tuple) -> Cursor
         """Execute a SQL statement.
 
         Parameters
@@ -144,13 +134,11 @@ class Cursor:
         -------
         results : list of lists
         """
-        # type: (str, Iterable) -> None
         results = [list(self.execute(operation, params)) for params
                    in parameters]
         return results
 
     def fetchone(self):
-        # type: () -> Optional[Any]
         """Fetch a single row from the results set"""
         try:
             return next(self.result_set)
@@ -158,7 +146,6 @@ class Cursor:
             return None
 
     def fetchmany(self, size=None):
-        # type: (Optional[int]) -> Iterable[Any]
         """Fetch ``size`` rows from the results set."""
         if size is None:
             size = self.arraysize
@@ -166,15 +153,12 @@ class Cursor:
         return [x for x in results if x is not None]
 
     def fetchall(self):
-        # type: () -> Any
         return list(self)
 
     def setinputsizes(self, sizes):
-        # type: (int) -> None
         pass
 
     def setoutputsizes(self, size, column=None):
-        # type: (int, Optional[Any]) -> None
         pass
 
 
@@ -183,7 +167,6 @@ class Cursor:
 # -----------------------------------------------------------------------------
 
 def make_row_results_set(data):
-    # type: (T.QueryResultSet) -> Iterator[Tuple]
     """
     Build a results set of python objects.
 

--- a/pymapd/dtypes.py
+++ b/pymapd/dtypes.py
@@ -3,8 +3,6 @@ https://www.python.org/dev/peps/pep-0249/#type-objects
 """
 import datetime
 import time
-from typing import Any, List
-
 from mapd import MapD
 
 
@@ -14,19 +12,15 @@ T = MapD.TDatumType
 class DataType:
 
     def __init__(self, matches):
-        # type: (List[Any]) -> None
         self._matches = set(matches)
 
     def __eq__(self, other):
-        # type: (Any) -> bool
         return other in self._matches
 
     def __ne__(self, other):
-        # type: (Any) -> bool
         return not (self == other)
 
     def __hash__(self):
-        # type: () -> int
         return hash(tuple(self._matches))
 
 
@@ -45,15 +39,12 @@ ROWID = DataType([])
 
 
 def DateFromTicks(ticks):
-    # type: (int) -> Date
     return Date(*time.localtime(ticks)[:3])
 
 
 def TimeFromTicks(ticks):
-    # type: (int) -> Time
     return Time(*time.localtime(ticks)[3:6])
 
 
 def TimestampFromTicks(ticks):
-    # type: (int) -> Timestamp
     return Timestamp(*time.localtime(ticks)[:6])


### PR DESCRIPTION
Per #161, type annotations are likely out-of-date. Currently, these annotations aren't being checked via CI, nor are they in the correct format for Python 3 (they are in Python 2 comment style).

Removing for now to provide a clean slate, so that if someone in the future chooses to incorporate typing, they will not have to wade through the legacy comments. 