### PR TITLE
Throw better exception when port incorrect

### DIFF
--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -172,6 +172,12 @@ class Connection:
             self._session = self._client.connect(user, password, dbname)
         except TMapDException as e:
             raise _translate_exception(e) from e
+        except TTransportException:
+            raise ValueError(f"Connection failed with port {port} and "
+                             f"protocol '{protocol}'. Try port 6274 for "
+                             "protocol == binary or 6273, 6278 or 443 for "
+                             "http[s]"
+                             )
 
         # if OmniSci version <4.6, raise RuntimeError, as data import can be
         # incorrect for columnar date loads


### PR DESCRIPTION
Fixes #199 

On connection, if you provide the wrong port/protocol combination, the server will respond with a `TSocket read 0 bytes` message. This PR catches the `TTransportException` error, suggests to user to evaluate their port/protocol combination