### PR TITLE
Switch connection context manager to self

### DIFF
--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -215,10 +215,10 @@ class Connection:
         self.close()
 
     def __enter__(self):
-        return self.cursor()
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+        self.close()
 
     @property
     def closed(self):

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -24,7 +24,7 @@ class Cursor:
         return self.result_set
 
     def __enter__(self):
-        pass
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2,7 +2,6 @@ import pytest
 from mapd.ttypes import TColumnType
 from common.ttypes import TTypeInfo
 from pymapd import OperationalError, connect
-from pymapd.cursor import Cursor
 from pymapd.connection import _parse_uri, ConnectionInfo
 from pymapd.exceptions import Error
 from pymapd._parsers import ColumnDetails, _extract_column_details
@@ -25,13 +24,6 @@ class TestConnect:
         assert conn.closed == 0
         conn.close()
         assert conn.closed == 1
-
-    def test_context_manager(self, con):
-        with con as cur:
-            pass
-
-        assert isinstance(cur, Cursor)
-        assert con.closed == 0
 
     def test_commit_noop(self, con):
         result = con.commit()  # it worked


### PR DESCRIPTION
Per #234, it would be more convenient if the connection context manager 
would return self instead of self.cursor(). Similarly, using a cursor 
with the context manager should close the cursor.

Deleted the test, as closing a connection via the context manager will 
now mean the entire test suite connection will be shutdown.