### PR TITLE
Update connection parameters

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,8 +13,8 @@ the `Apache Arrow`_-based `cudf GPU DataFrame`_ format for efficient data interc
 .. code-block:: python
 
    >>> from pymapd import connect
-   >>> con = connect(user="mapd", password="HyperInteractive", host="localhost",
-   ...               dbname="mapd")
+   >>> con = connect(user="admin", password="HyperInteractive", host="localhost",
+   ...               dbname="omnisci")
    >>> df = con.select_ipc_gpu("SELECT depdelay, arrdelay"
    ...                         "FROM flights_2008_10k"
    ...                         "LIMIT 100")

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -73,19 +73,19 @@ To create a :class:`Connection` using the ``connect()`` method along with ``user
 .. code-block:: python
 
    >>> from pymapd import connect
-   >>> con = connect(user="mapd", password="HyperInteractive", host="localhost",
-   ...               dbname="mapd")
+   >>> con = connect(user="admin", password="HyperInteractive", host="localhost",
+   ...               dbname="omnisci")
    >>> con
-   Connection(mapd://mapd:***@localhost:6274/mapd?protocol=binary)
+   Connection(mapd://admin:***@localhost:6274/omnisci?protocol=binary)
 
 Alternatively, you can pass in a `SQLAlchemy`_-compliant connection string to
 the ``connect()`` method:
 
 .. code-block:: python
 
-   >>> uri = "mapd://mapd:HyperInteractive@localhost:6274/mapd?protocol=binary"
+   >>> uri = "mapd://admin:HyperInteractive@localhost:6274/omnisci?protocol=binary"
    >>> con = connect(uri=uri)
-   Connection(mapd://mapd:***@localhost:6274/mapd?protocol=binary)
+   Connection(mapd://admin:***@localhost:6274/omnisci?protocol=binary)
 
 OmniSci Cloud
 *************
@@ -170,8 +170,8 @@ install, ``pandas.read_sql()`` works everywhere):
 
    >>> from pymapd import connect
    >>> import pandas as pd
-   >>> con = connect(user="mapd", password="HyperInteractive", host="localhost",
-   ...               dbname="mapd")
+   >>> con = connect(user="admin", password="HyperInteractive", host="localhost",
+   ...               dbname="omnisci")
    >>> df = pd.read_sql("SELECT depdelay, arrdelay FROM flights_2008_10k limit 100", con)
 
 

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -206,8 +206,8 @@ class Connection:
                                "for more details.")
 
     def __repr__(self):
-        tpl = ('Connection(omnisci://{user}:***@{host}:{port}/{dbname}?protocol'
-               '={protocol})')
+        tpl = ('Connection(omnisci://{user}:***@{host}:{port}/{dbname}?'
+               'protocol={protocol})')
         return tpl.format(user=self._user, host=self._host, port=self._port,
                           dbname=self._dbname, protocol=self._protocol)
 

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -206,7 +206,7 @@ class Connection:
                                "for more details.")
 
     def __repr__(self):
-        tpl = ('Connection(mapd://{user}:***@{host}:{port}/{dbname}?protocol'
+        tpl = ('Connection(omnisci://{user}:***@{host}:{port}/{dbname}?protocol'
                '={protocol})')
         return tpl.format(user=self._user, host=self._host, port=self._port,
                           dbname=self._dbname, protocol=self._protocol)

--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -67,12 +67,12 @@ def connect(uri=None,
     You can either pass a string ``uri``, all the individual components,
     or an existing sessionid excluding user, password, and database
 
-    >>> connect('mapd://mapd:HyperInteractive@localhost:6274/mapd?'
+    >>> connect('mapd://admin:HyperInteractive@localhost:6274/omnisci?'
     ...         'protocol=binary')
     Connection(mapd://mapd:***@localhost:6274/mapd?protocol=binary)
 
-    >>> connect(user='mapd', password='HyperInteractive', host='localhost',
-    ...         port=6274, dbname='mapd')
+    >>> connect(user='admin', password='HyperInteractive', host='localhost',
+    ...         port=6274, dbname='omnisci')
 
     >>> connect(sessionid='XihlkjhdasfsadSDoasdllMweieisdpo', host='localhost',
     ...         port=6273, protocol='http')

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -218,9 +218,9 @@ def main(args=None):
     logger.addHandler(fh)
 
     con = pymapd.connect(
-        user='mapd',
+        user='admin',
         password='HyperInteractive',
-        dbname='mapd',
+        dbname='omnisci',
         host='localhost')
 
     grid = product(selects.keys(), _benchmarks)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,8 +51,8 @@ def con(mapd_server):
     """
     Fixture to provide Connection for tests run against live OmniSci instance
     """
-    return connect(user="mapd", password='HyperInteractive', host='localhost',
-                   port=6274, protocol='binary', dbname='mapd')
+    return connect(user="admin", password='HyperInteractive', host='localhost',
+                   port=6274, protocol='binary', dbname='omnisci')
 
 
 @pytest.fixture

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -19,8 +19,8 @@ class TestConnect:
             connect(host='localhost', protocol='binary', port=1234)
 
     def test_close(self):
-        conn = connect(user='mapd', password='HyperInteractive',
-                       host='localhost', dbname='mapd')
+        conn = connect(user='admin', password='HyperInteractive',
+                       host='localhost', dbname='omnisci')
         assert conn.closed == 0
         conn.close()
         assert conn.closed == 1
@@ -36,8 +36,8 @@ class TestConnect:
         assert m.match('fake-proto')
 
     def test_session_logon_success(self):
-        conn = connect(user='mapd', password='HyperInteractive',
-                       host='localhost', dbname='mapd')
+        conn = connect(user='admin', password='HyperInteractive',
+                       host='localhost', dbname='omnisci')
         sessionid = conn._session
         connnew = connect(sessionid=sessionid, host='localhost')
         assert connnew._session == sessionid
@@ -51,15 +51,15 @@ class TestConnect:
 class TestURI:
 
     def test_parse_uri(self):
-        uri = ('mapd://mapd:HyperInteractive@localhost:6274/mapd?'
+        uri = ('mapd://admin:HyperInteractive@localhost:6274/omnisci?'
                'protocol=binary')
         result = _parse_uri(uri)
-        expected = ConnectionInfo("mapd", "HyperInteractive", "localhost",
-                                  6274, "mapd", "binary")
+        expected = ConnectionInfo("admin", "HyperInteractive", "localhost",
+                                  6274, "omnisci", "binary")
         assert result == expected
 
     def test_both_raises(self):
-        uri = ('mapd://mapd:HyperInteractive@localhost:6274/mapd?'
+        uri = ('mapd://admin:HyperInteractive@localhost:6274/omnisci?'
                'protocol=binary')
         with pytest.raises(TypeError):
             connect(uri=uri, user='my user')

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -51,7 +51,7 @@ class TestConnect:
 class TestURI:
 
     def test_parse_uri(self):
-        uri = ('mapd://admin:HyperInteractive@localhost:6274/omnisci?'
+        uri = ('omnisci://admin:HyperInteractive@localhost:6274/omnisci?'
                'protocol=binary')
         result = _parse_uri(uri)
         expected = ConnectionInfo("admin", "HyperInteractive", "localhost",
@@ -59,7 +59,7 @@ class TestURI:
         assert result == expected
 
     def test_both_raises(self):
-        uri = ('mapd://admin:HyperInteractive@localhost:6274/omnisci?'
+        uri = ('omnisci://admin:HyperInteractive@localhost:6274/omnisci?'
                'protocol=binary')
         with pytest.raises(TypeError):
             connect(uri=uri, user='my user')

--- a/tests/test_deallocate.py
+++ b/tests/test_deallocate.py
@@ -17,10 +17,10 @@ class TestDeallocate:
 
     def _connect(self):
 
-        return connect(user="mapd",
+        return connect(user="admin",
                        password='HyperInteractive',
                        host='localhost',
-                       port=6274, protocol='binary', dbname='mapd')
+                       port=6274, protocol='binary', dbname='omnisci')
 
     def _transact(self, con):
         drop = 'drop table if exists iris;'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,33 +29,33 @@ TMapDException.__hash__ = lambda x: id(x)
 class TestIntegration:
 
     def test_connect_binary(self):
-        con = connect(user="mapd", password='HyperInteractive',
+        con = connect(user="admin", password='HyperInteractive',
                       host='localhost', port=6274, protocol='binary',
-                      dbname='mapd')
+                      dbname='omnisci')
         assert con is not None
 
     def test_connect_http(self):
-        con = connect(user="mapd", password='HyperInteractive',
+        con = connect(user="admin", password='HyperInteractive',
                       host='localhost', port=6278, protocol='http',
-                      dbname='mapd')
+                      dbname='omnisci')
         assert con is not None
 
     def test_connect_uri(self):
-        uri = ('mapd://mapd:HyperInteractive@localhost:6274/mapd?protocol='
+        uri = ('mapd://admin:HyperInteractive@localhost:6274/omnisci?protocol='
                'binary')
         con = connect(uri=uri)
-        assert con._user == 'mapd'
+        assert con._user == 'admin'
         assert con._password == 'HyperInteractive'
         assert con._host == 'localhost'
         assert con._port == 6274
-        assert con._dbname == 'mapd'
+        assert con._dbname == 'omnisci'
         assert con._protocol == 'binary'
 
     def test_connect_uri_and_others_raises(self):
-        uri = ('mapd://mapd:HyperInteractive@localhost:6274/mapd?protocol='
+        uri = ('mapd://admin:HyperInteractive@localhost:6274/omnisci?protocol='
                'binary')
         with pytest.raises(TypeError):
-            connect(username='mapd', uri=uri)
+            connect(username='omnisci', uri=uri)
 
     def test_invalid_sql(self, con):
         with pytest.raises(ProgrammingError) as r:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,7 +41,7 @@ class TestIntegration:
         assert con is not None
 
     def test_connect_uri(self):
-        uri = ('mapd://admin:HyperInteractive@localhost:6274/omnisci?protocol='
+        uri = ('omnisci://admin:HyperInteractive@localhost:6274/omnisci?protocol='
                'binary')
         con = connect(uri=uri)
         assert con._user == 'admin'
@@ -52,7 +52,7 @@ class TestIntegration:
         assert con._protocol == 'binary'
 
     def test_connect_uri_and_others_raises(self):
-        uri = ('mapd://admin:HyperInteractive@localhost:6274/omnisci?protocol='
+        uri = ('omnisci://admin:HyperInteractive@localhost:6274/omnisci?protocol='
                'binary')
         with pytest.raises(TypeError):
             connect(username='omnisci', uri=uri)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,8 +41,8 @@ class TestIntegration:
         assert con is not None
 
     def test_connect_uri(self):
-        uri = ('omnisci://admin:HyperInteractive@localhost:6274/omnisci?protocol='
-               'binary')
+        uri = ('omnisci://admin:HyperInteractive@localhost:6274/omnisci?'
+               'protocol=binary')
         con = connect(uri=uri)
         assert con._user == 'admin'
         assert con._password == 'HyperInteractive'
@@ -52,8 +52,8 @@ class TestIntegration:
         assert con._protocol == 'binary'
 
     def test_connect_uri_and_others_raises(self):
-        uri = ('omnisci://admin:HyperInteractive@localhost:6274/omnisci?protocol='
-               'binary')
+        uri = ('omnisci://admin:HyperInteractive@localhost:6274/omnisci?'
+               'protocol=binary')
         with pytest.raises(TypeError):
             connect(username='omnisci', uri=uri)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -339,6 +339,13 @@ class TestIntegration:
                 }
         dashboard_id = ""
 
+        # check and remove existing dashboards
+        dashboards = con._client.get_dashboards(con._session)
+        for dash in dashboards:
+            if dash.dashboard_name == old_dashboard_name or dash.dashboard_name == new_dashboard_name:
+                con._client.delete_dashboard(con._session, dash.dashboard_id)
+                break
+
         # Create testing dashboard
         con._client.create_dashboard(
             session=con._session,


### PR DESCRIPTION
As per the new changes in core, update default user name and database name to `admin` and `omnisci` respectively
Similar updates to documentation
Update connection parameters unit tests

cc: @mattdlh 

I have not changed the connection URL to start with `omnisci`:
```
>>> pymapd.connect(user="admin", password="HyperInteractive",host="localhost",dbname="omnisci") 
Connection(mapd://admin:***@localhost:6274/omnisci?protocol=binary) 
```
It still starts with `mapd` left it to be in sync with repository name `pymapd`.  Please let me know if that should be changed as well.