### PR TITLE
added is_array boolean flag to get_table_details

### DIFF
--- a/pymapd/_parsers.py
+++ b/pymapd/_parsers.py
@@ -19,7 +19,7 @@ Description = namedtuple("Description", ["name", "type_code", "display_size",
                                          "null_ok"])
 ColumnDetails = namedtuple("ColumnDetails", ["name", "type", "nullable",
                                              "precision", "scale",
-                                             "comp_param", "encoding", 
+                                             "comp_param", "encoding",
                                              "is_array"])
 
 _typeattr = {
@@ -120,7 +120,7 @@ def _extract_column_details(row_desc):
         ColumnDetails(x.col_name, _thrift_values_to_types[x.col_type.type],
                       x.col_type.nullable, x.col_type.precision,
                       x.col_type.scale, x.col_type.comp_param,
-                      _thrift_values_to_encodings[x.col_type.encoding], 
+                      _thrift_values_to_encodings[x.col_type.encoding],
                       x.col_type.is_array)
         for x in row_desc
     ]

--- a/pymapd/_parsers.py
+++ b/pymapd/_parsers.py
@@ -19,7 +19,8 @@ Description = namedtuple("Description", ["name", "type_code", "display_size",
                                          "null_ok"])
 ColumnDetails = namedtuple("ColumnDetails", ["name", "type", "nullable",
                                              "precision", "scale",
-                                             "comp_param", "encoding", "is_array"])
+                                             "comp_param", "encoding", 
+                                             "is_array"])
 
 _typeattr = {
     'SMALLINT': 'int',
@@ -119,7 +120,8 @@ def _extract_column_details(row_desc):
         ColumnDetails(x.col_name, _thrift_values_to_types[x.col_type.type],
                       x.col_type.nullable, x.col_type.precision,
                       x.col_type.scale, x.col_type.comp_param,
-                      _thrift_values_to_encodings[x.col_type.encoding], x.col_type.is_array)
+                      _thrift_values_to_encodings[x.col_type.encoding], 
+                      x.col_type.is_array)
         for x in row_desc
     ]
 

--- a/pymapd/_parsers.py
+++ b/pymapd/_parsers.py
@@ -19,7 +19,7 @@ Description = namedtuple("Description", ["name", "type_code", "display_size",
                                          "null_ok"])
 ColumnDetails = namedtuple("ColumnDetails", ["name", "type", "nullable",
                                              "precision", "scale",
-                                             "comp_param", "encoding"])
+                                             "comp_param", "encoding", "is_array"])
 
 _typeattr = {
     'SMALLINT': 'int',
@@ -119,7 +119,7 @@ def _extract_column_details(row_desc):
         ColumnDetails(x.col_name, _thrift_values_to_types[x.col_type.type],
                       x.col_type.nullable, x.col_type.precision,
                       x.col_type.scale, x.col_type.comp_param,
-                      _thrift_values_to_encodings[x.col_type.encoding])
+                      _thrift_values_to_encodings[x.col_type.encoding], x.col_type.is_array)
         for x in row_desc
     ]
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -102,17 +102,23 @@ class TestExtras:
 
         expected = [
             ColumnDetails(name='date_', type='STR', nullable=True, precision=0,
-                          scale=0, comp_param=32, encoding='DICT'),
+                          scale=0, comp_param=32, encoding='DICT',
+                          is_array=False),
             ColumnDetails(name='trans', type='STR', nullable=True, precision=0,
-                          scale=0, comp_param=32, encoding='DICT'),
+                          scale=0, comp_param=32, encoding='DICT',
+                          is_array=False),
             ColumnDetails(name='symbol', type='STR', nullable=True,
                           precision=0, scale=0, comp_param=32,
-                          encoding='DICT'),
+                          encoding='DICT',
+                          is_array=False),
             ColumnDetails(name='qty', type='INT', nullable=True, precision=0,
-                          scale=0, comp_param=0, encoding='NONE'),
+                          scale=0, comp_param=0, encoding='NONE',
+                          is_array=False),
             ColumnDetails(name='price', type='FLOAT', nullable=True,
-                          precision=0, scale=0, comp_param=0, encoding='NONE'),
+                          precision=0, scale=0, comp_param=0, encoding='NONE',
+                          is_array=False),
             ColumnDetails(name='vol', type='FLOAT', nullable=True, precision=0,
-                          scale=0, comp_param=0, encoding='NONE')
+                          scale=0, comp_param=0, encoding='NONE',
+                          is_array=False)
         ]
         assert result == expected

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -435,10 +435,10 @@ class TestExtras:
         c = con.cursor()
         c.execute('drop table if exists stocks;')
         create = ('create table stocks (date_ text, trans text, symbol text, '
-                  'qty int, price float, vol float);')
+                  'qty int, price float, vol float, exchanges TEXT [] ENCODING DICT(32));')
         c.execute(create)
-        i1 = "INSERT INTO stocks VALUES ('2006-01-05','BUY','RHAT',100,35.14,1.1);"  # noqa
-        i2 = "INSERT INTO stocks VALUES ('2006-01-05','BUY','GOOG',100,12.14,1.2);"  # noqa
+        i1 = "INSERT INTO stocks VALUES ('2006-01-05','BUY','RHAT',100,35.14,1.1,{'NYSE', 'NASDAQ', 'AMEX'});"  # noqa
+        i2 = "INSERT INTO stocks VALUES ('2006-01-05','BUY','GOOG',100,12.14,1.2,{'NYSE', 'NASDAQ'});"  # noqa
 
         c.execute(i1)
         c.execute(i2)
@@ -462,11 +462,13 @@ class TestExtras:
                           is_array=False),
             ColumnDetails(name='vol', type='FLOAT', nullable=True, precision=0,
                           scale=0, comp_param=0, encoding='NONE',
-                          is_array=False)
+                          is_array=False),
+            ColumnDetails(name='exchanges',type='STR',nullable=True, precision=0,
+            scale=0,comp_param=32,encoding='DICT',
+            is_array=True)
         ]
         assert result == expected
         c.execute('drop table if exists stocks;')
-
 
 class TestLoaders:
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -822,9 +822,9 @@ class TestLoaders:
         
         assert con.get_table_details("test_categorical") == \
             [ColumnDetails(name='A', type='STR', nullable=True, precision=0,
-                           scale=0, comp_param=32, encoding='DICT', is_array=False),
+                           scale=0, comp_param=32, encoding='DICT',is_array=False),
              ColumnDetails(name='B', type='STR', nullable=True, precision=0,
-                           scale=0, comp_param=32, encoding='DICT', is_array=False)]
+                           scale=0, comp_param=32, encoding='DICT',is_array=False)]
 
         # load row-wise
         con.load_table("test_categorical", df, method="rows")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -446,18 +446,23 @@ class TestExtras:
         result = con.get_table_details('stocks')
         expected = [
             ColumnDetails(name='date_', type='STR', nullable=True, precision=0,
-                          scale=0, comp_param=32, encoding='DICT'),
+                          scale=0, comp_param=32, encoding='DICT',
+                          is_array=False),
             ColumnDetails(name='trans', type='STR', nullable=True, precision=0,
-                          scale=0, comp_param=32, encoding='DICT'),
+                          scale=0, comp_param=32, encoding='DICT',
+                          is_array=False),
             ColumnDetails(name='symbol', type='STR', nullable=True,
                           precision=0, scale=0, comp_param=32,
-                          encoding='DICT'),
+                          encoding='DICT', is_array=False),
             ColumnDetails(name='qty', type='INT', nullable=True, precision=0,
-                          scale=0, comp_param=0, encoding='NONE'),
+                          scale=0, comp_param=0, encoding='NONE',
+                          is_array=False),
             ColumnDetails(name='price', type='FLOAT', nullable=True,
-                          precision=0, scale=0, comp_param=0, encoding='NONE'),
+                          precision=0, scale=0, comp_param=0, encoding='NONE',
+                          is_array=False),
             ColumnDetails(name='vol', type='FLOAT', nullable=True, precision=0,
-                          scale=0, comp_param=0, encoding='NONE')
+                          scale=0, comp_param=0, encoding='NONE',
+                          is_array=False)
         ]
         assert result == expected
         c.execute('drop table if exists stocks;')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -819,12 +819,12 @@ class TestLoaders:
         ans = con.execute("select * from test_categorical").fetchall()
 
         assert ans == [('a', 'a'), ('b', 'b'), ('c', 'c'), ('a', 'a')]
-
+        
         assert con.get_table_details("test_categorical") == \
             [ColumnDetails(name='A', type='STR', nullable=True, precision=0,
-                           scale=0, comp_param=32, encoding='DICT'),
+                           scale=0, comp_param=32, encoding='DICT', is_array=False),
              ColumnDetails(name='B', type='STR', nullable=True, precision=0,
-                           scale=0, comp_param=32, encoding='DICT')]
+                           scale=0, comp_param=32, encoding='DICT', is_array=False)]
 
         # load row-wise
         con.load_table("test_categorical", df, method="rows")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -435,7 +435,8 @@ class TestExtras:
         c = con.cursor()
         c.execute('drop table if exists stocks;')
         create = ('create table stocks (date_ text, trans text, symbol text, '
-                  'qty int, price float, vol float, exchanges TEXT [] ENCODING DICT(32));')
+                  'qty int, price float, vol float, '
+                  'exchanges TEXT [] ENCODING DICT(32));')
         c.execute(create)
         i1 = "INSERT INTO stocks VALUES ('2006-01-05','BUY','RHAT',100,35.14,1.1,{'NYSE', 'NASDAQ', 'AMEX'});"  # noqa
         i2 = "INSERT INTO stocks VALUES ('2006-01-05','BUY','GOOG',100,12.14,1.2,{'NYSE', 'NASDAQ'});"  # noqa
@@ -463,12 +464,13 @@ class TestExtras:
             ColumnDetails(name='vol', type='FLOAT', nullable=True, precision=0,
                           scale=0, comp_param=0, encoding='NONE',
                           is_array=False),
-            ColumnDetails(name='exchanges',type='STR',nullable=True, precision=0,
-            scale=0,comp_param=32,encoding='DICT',
-            is_array=True)
+            ColumnDetails(name='exchanges', type='STR', nullable=True,
+                          precision=0, scale=0, comp_param=32, encoding='DICT',
+                          is_array=True)
         ]
         assert result == expected
         c.execute('drop table if exists stocks;')
+
 
 class TestLoaders:
 
@@ -824,9 +826,11 @@ class TestLoaders:
 
         assert con.get_table_details("test_categorical") == \
             [ColumnDetails(name='A', type='STR', nullable=True, precision=0,
-                           scale=0, comp_param=32, encoding='DICT',is_array=False),
+                           scale=0, comp_param=32, encoding='DICT',
+                           is_array=False),
              ColumnDetails(name='B', type='STR', nullable=True, precision=0,
-                           scale=0, comp_param=32, encoding='DICT',is_array=False)]
+                           scale=0, comp_param=32, encoding='DICT',
+                           is_array=False)]
 
         # load row-wise
         con.load_table("test_categorical", df, method="rows")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -819,7 +819,7 @@ class TestLoaders:
         ans = con.execute("select * from test_categorical").fetchall()
 
         assert ans == [('a', 'a'), ('b', 'b'), ('c', 'c'), ('a', 'a')]
-        
+
         assert con.get_table_details("test_categorical") == \
             [ColumnDetails(name='A', type='STR', nullable=True, precision=0,
                            scale=0, comp_param=32, encoding='DICT',is_array=False),


### PR DESCRIPTION
I'm doing some automated cardinality generation in pymapd and I wasn't able to figure out if a column is an array type when running certain cardinality functions. This now exposes is_array from https://github.com/omnisci/omniscidb/blob/fae988dc374099b877ec90a8154b658241ccbfb4/common.thrift#L46
Resolves https://jira.omnisci.com/browse/BE-3837 