### PR TITLE
Change CI to build package, then install it

### DIFF
--- a/ci/install-test-deps-conda.sh
+++ b/ci/install-test-deps-conda.sh
@@ -29,7 +29,8 @@ cudatoolkit
 
 conda activate omnisci-dev
 
-pip install -e .
+python setup.py sdist
+pip install dist/*.tar.gz
 conda list omnisci-dev
 echo
 exit 0

--- a/ci/install-test-deps-pip.sh
+++ b/ci/install-test-deps-pip.sh
@@ -4,4 +4,5 @@
 
 pip install -r ci/requirements.txt
 
-pip install -e .
+python setup.py sdist
+pip install dist/*.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3 :: Only',
     ],
-    packages=find_packages(),
+    packages=[None],
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from codecs import open
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
This change is to avoid situation where code present in source, but then 
not properly recorded in setup.py, leading to a broken build.

Fixes #257 