### PR TITLE
Pin cudf to 0.8 in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ def flake8_container_image = "alpine/flake8:3.7.7"
 def flake8_container_name = "pymapd-flake8-$BUILD_NUMBER"
 def db_container_image = "omnisci/core-os-cuda-dev:master"
 def db_container_name = "pymapd-db-$BUILD_NUMBER"
-def testscript_container_image = "rapidsai/rapidsai:cuda10.0-runtime-ubuntu18.04"
+def testscript_container_image = "rapidsai/rapidsai:0.8-cuda10.0-runtime-ubuntu18.04-gcc7-py3.6"
 def testscript_container_name = "pymapd-pytest-$BUILD_NUMBER"
 def stage_succeeded
 


### PR DESCRIPTION
OmniSci currently does not support Arrow 0.14, meaning that we need to pin cudf at the last known good release in Jenkins