### PR TITLE
Ensure execute() 'operation' argument trimmed before sending

### DIFF
--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -286,7 +286,7 @@ class Connection:
         c: Cursor
         """
         c = Cursor(self)
-        return c.execute(operation.strip(), parameters=parameters)
+        return c.execute(operation, parameters=parameters)
 
     def cursor(self):
         """Create a new :class:`Cursor` object attached to this connection."""

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -104,7 +104,7 @@ class Cursor:
 
         # https://github.com/omnisci/pymapd/issues/263
         operation = operation.strip()
-        
+
         if parameters is not None:
             operation = str(_bind_parameters(operation, parameters))
         self.rowcount = -1

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -101,6 +101,10 @@ class Cursor:
         ...           parameters={"max_qty": 500})
         [('RHAT', 100.0), ('IBM', 500.0)]
         """
+
+        # https://github.com/omnisci/pymapd/issues/263
+        operation = operation.strip()
+        
         if parameters is not None:
             operation = str(_bind_parameters(operation, parameters))
         self.rowcount = -1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -909,7 +909,7 @@ class TestLoaders:
 
                     INSERT INTO test_leading_spaces
 
-                    
+
                     VALUES ( :value );
 
                             """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -889,3 +889,32 @@ class TestLoaders:
         c.execute(i1, parameters=second)
 
         c.execute('drop table if exists text_holder;')
+
+    def test_execute_leading_space_and_params(self, con):
+
+        # https://github.com/omnisci/pymapd/issues/263
+
+        """Ensure that leading/trailing spaces in execute statements
+           don't cause issues
+        """
+
+        c = con.cursor()
+        c.execute('drop table if exists test_leading_spaces;')
+        create = ('create table test_leading_spaces (the_text text);')
+        c.execute(create)
+        first = {"value": "我和我的姐姐吃米饭鸡肉"}
+        second = {"value": "El camina a case en bicicleta es relajante"}
+
+        i1 = """
+
+                    INSERT INTO test_leading_spaces
+
+                    
+                    VALUES ( :value );
+
+                            """
+
+        c.execute(i1, parameters=first)
+        c.execute(i1, parameters=second)
+
+        c.execute('drop table if exists test_leading_spaces;')


### PR DESCRIPTION
Fixes #263, where submitting a query using parameters with leading spaces causes an error