### PR TITLE
register_runtime_udfs in cursor

### DIFF
--- a/pymapd/connection.py
+++ b/pymapd/connection.py
@@ -287,7 +287,6 @@ class Connection:
         -------
         c: Cursor
         """
-        self.register_runtime_udfs()
         c = Cursor(self)
         return c.execute(operation, parameters=parameters)
 

--- a/pymapd/cursor.py
+++ b/pymapd/cursor.py
@@ -17,6 +17,8 @@ class Cursor:
         self._arraysize = 1
         self._result = None
         self._result_set = None
+        if connection:
+            connection.register_runtime_udfs()
 
     def __iter__(self):
         if self.result_set is None:

--- a/tests/test_runtime_udf.py
+++ b/tests/test_runtime_udf.py
@@ -1,4 +1,7 @@
 import pytest
+import pandas as pd
+import numpy as np
+import pandas.util.testing as tm
 pytest.importorskip('rbc')
 
 
@@ -20,6 +23,12 @@ def catch_udf_support_disabled(mth):
 @pytest.mark.usefixtures("mapd_server")
 class TestRuntimeUDF:
 
+    def load_test_udf_incr(self, con):
+        con.execute('drop table if exists test_udf_incr')
+        con.execute('create table test_udf_incr (i4 integer, f8 double)')
+        con.execute('insert into test_udf_incr values (1, 2.3);')
+        con.execute('insert into test_udf_incr values (2, 3.4);')
+
     @catch_udf_support_disabled
     def test_udf_incr(self, con):
 
@@ -27,10 +36,7 @@ class TestRuntimeUDF:
         def incr(x):
             return x + 1
 
-        con.execute('drop table if exists test_udf_incr')
-        con.execute('create table test_udf_incr (i4 integer, f8 double)')
-        con.execute('insert into test_udf_incr values (1, 2.3);')
-        con.execute('insert into test_udf_incr values (2, 3.4);')
+        self.load_test_udf_incr(con)
 
         result = list(con.execute('select i4, incr(i4) from test_udf_incr'))
         expected = [(1, 2), (2, 3)]
@@ -39,5 +45,34 @@ class TestRuntimeUDF:
         result = list(con.execute('select f8, incr(f8) from test_udf_incr'))
         expected = [(2.3, 3.3), (3.4, 4.4)]
         assert result == expected
+
+        con.execute('drop table if exists test_udf_incr')
+
+    @catch_udf_support_disabled
+    def test_udf_incr_read_sql(self, con):
+
+        @con('int32(int32)', 'double(double)')
+        def incr_read_sql(x):
+            return x + 1
+
+        self.load_test_udf_incr(con)
+
+        result = pd.read_sql(
+            '''select i4 as qty, incr_read_sql(i4) as price
+               from test_udf_incr''', con)
+        expected = pd.DataFrame({
+            "qty": np.array([1, 2], dtype=np.int64),
+            "price": np.array([2, 3], dtype=np.int64)
+        })[['qty', 'price']]
+        tm.assert_frame_equal(result, expected)
+
+        result = pd.read_sql(
+            '''select f8 as qty, incr_read_sql(f8) as price
+               from test_udf_incr''', con)
+        expected = pd.DataFrame({
+            "qty": np.array([2.3, 3.4], dtype=np.float64),
+            "price": np.array([3.3, 4.4], dtype=np.float64)
+        })[['qty', 'price']]
+        tm.assert_frame_equal(result, expected)
 
         con.execute('drop table if exists test_udf_incr')


### PR DESCRIPTION
for clients that use cursor.execute instead of con.execute

otherwise, usage like pd.read_sql would not register the udfs automatically