### PR TITLE
rbc: pin to v0.2.0dev0

### DIFF
--- a/ci/install-test-deps-conda.sh
+++ b/ci/install-test-deps-conda.sh
@@ -13,8 +13,8 @@ conda create -n omnisci-dev python=${PYTHON} \
 thrift=0.11.0 \
 numpydoc \
 "pyarrow>=0.12.0,<0.14" \
-sqlalchemy>=1.3 \
-numpy>=1.16 \
+"sqlalchemy>=1.3" \
+"numpy>=1.16" \
 "pandas>=1.0,<2.0" \
 coverage \
 flake8 \
@@ -25,7 +25,7 @@ shapely \
 numba \
 cudf \
 cudatoolkit \
-rbc
+"rbc=0.2.0dev0"
 
 conda activate omnisci-dev
 

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -12,4 +12,4 @@ pytest-mock
 shapely
 numba
 cudf
-rbc-project
+rbc-project==0.2.0dev0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requires = ['thrift == 0.11.0',
                     'pandas >= 1.0,<2.0',
                     'pyarrow >= 0.12.0,<0.14',
                     'packaging >= 20.0',
-                    'rbc-project']
+                    'rbc-project == 0.2.0dev0']
 
 # Optional Requirements
 


### PR DESCRIPTION
Pin version of RBC because rbc 0.2.1 has a breaking change:
renames the package from mapd to omnisci

Also, fix conda version specs in ci script, though this may actually break the CI test.