### PR TITLE
Add support for datetime64

### DIFF
--- a/pymapd/_pandas_loaders.py
+++ b/pymapd/_pandas_loaders.py
@@ -292,4 +292,8 @@ def build_row_desc(data, preserve_index=False):
             tct.col_type.encoding = 4
         elif tct.col_type.type in GEO_TYPE_ID:
             tct.col_type.precision = 23
+        elif tct.col_type.type == 8:
+            # force precision for timestamp with nanoseconds
+            if data[tct.col_name].dt.nanosecond.sum():
+                tct.col_type.precision = 9
     return row_desc

--- a/pymapd/_pandas_loaders.py
+++ b/pymapd/_pandas_loaders.py
@@ -77,6 +77,8 @@ def get_mapd_type_from_object(data):
 
     if isinstance(val, str):
         return 'STR'
+    elif isinstance(val, np.datetime64):
+        return 'TIMESTAMP'
     elif isinstance(val, datetime.date):
         return 'DATE'
     elif isinstance(val, datetime.time):

--- a/pymapd/_utils.py
+++ b/pymapd/_utils.py
@@ -24,20 +24,27 @@ def datetime_to_seconds(arr):
         if arr.dtype == 'int64':
             # The user has passed a unix timestamp already
             return arr
-        elif arr.dtype == 'object' or str(arr.dtype).startswith(
-            'datetime64[ns,'
+
+        if not (
+            arr.dtype == 'object'
+            or str(arr.dtype).startswith('datetime64[ns,')
         ):
-            # Convert to datetime64[ns] from string
-            # Or from datetime with timezone information
-            # Return timestamp in 'UTC'
-            arr = pd.to_datetime(arr, utc=True)
-        else:
             raise TypeError(
                 f"Invalid dtype '{arr.dtype}', expected one of: "
                 "datetime64[ns], int64 (UNIX epoch), "
                 "or object (string)"
             )
-    return arr.view('i8') // 10 ** 9  # ns -> s since epoch
+
+        # Convert to datetime64[ns] from string
+        # Or from datetime with timezone information
+        # Return timestamp in 'UTC'
+        arr = pd.to_datetime(arr, utc=True)
+        return arr.view('i8') // 10 ** 9  # ns -> s since epoch
+    else:
+        if arr.dt.nanosecond.sum():
+            return arr.view('i8')  # ns -> s since epoch
+        else:
+            return arr.view('i8') // 10 ** 9
 
 
 def datetime_in_precisions(epoch, precision):

--- a/pymapd/_utils.py
+++ b/pymapd/_utils.py
@@ -52,12 +52,7 @@ def datetime_in_precisions(epoch, precision):
         seconds, modulus = divmod(epoch, 1000000)
         return base + datetime.timedelta(seconds=seconds, microseconds=modulus)
     elif precision == 9:
-        """ TODO(Wamsi): datetime.timedelta has support only till microseconds.
-                         Need to find an alternative and fix nanoseconds
-                         granularity"""
-        epoch /= 1000
-        seconds, modulus = divmod(epoch, 1000000)
-        return base + datetime.timedelta(seconds=seconds, microseconds=modulus)
+        return np.datetime64(epoch, 'ns')
     else:
         raise TypeError("Invalid timestamp precision: {}".format(precision))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -711,6 +711,19 @@ class TestLoaders:
             ),
             pytest.param(
                 pd.DataFrame(
+                    {
+                        "a": [
+                            np.datetime64('2010-01-01 01:01:01.001001001'),
+                            np.datetime64('2011-01-01 01:01:01.001001001'),
+                            np.datetime64('2012-01-01 01:01:01.001001001'),
+                        ],
+                    },
+                ),
+                'a TIMESTAMP(9)',
+                id='scalar_datetime_nanoseconds',
+            ),
+            pytest.param(
+                pd.DataFrame(
                     [
                         {'ary': [2, 3, 4]},
                         {'ary': [4444]},
@@ -1135,7 +1148,6 @@ class TestLoaders:
     def test_create_table(self, con, tmp_table, df, expected):
         con.create_table(tmp_table, df)
         cur = con.execute('SELECT * FROM {}'.format(tmp_table))
-        # import pdb; pdb.set_trace()
         for col in cur.description:
             assert expected[col.name]['type_code'] == col.type_code
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -102,19 +102,51 @@ def get_expected(data, col_properties):
 
 class TestLoaders:
     def test_build_input_rows(self):
-        data = [(1, 'a'), (2, 'b')]
+        dt_microsecond_format = '%Y-%m-%d %H:%M:%S.%f'
+
+        def get_dt_nanosecond(v):
+            return np.datetime64('201{}-01-01 01:01:01.001001001'.format(v))
+
+        def get_dt_microsecond(v):
+            return datetime.datetime.strptime(
+                '201{}-01-01 01:01:01.001001'.format(v), dt_microsecond_format
+            )
+
+        data = [
+            (1, 'a', get_dt_nanosecond(1), get_dt_microsecond(1)),
+            (2, 'b', get_dt_nanosecond(2), get_dt_microsecond(2)),
+        ]
         result = _build_input_rows(data)
+        # breakpoint
         expected = [
             TStringRow(
                 cols=[
                     TStringValue(str_val='1', is_null=None),
                     TStringValue(str_val='a', is_null=None),
+                    TStringValue(
+                        str_val=get_dt_nanosecond(1).astype(str), is_null=None
+                    ),
+                    TStringValue(
+                        str_val=get_dt_microsecond(1).strftime(
+                            dt_microsecond_format
+                        ),
+                        is_null=None,
+                    ),
                 ]
             ),
             TStringRow(
                 cols=[
                     TStringValue(str_val='2', is_null=None),
                     TStringValue(str_val='b', is_null=None),
+                    TStringValue(
+                        str_val=get_dt_nanosecond(2).astype(str), is_null=None
+                    ),
+                    TStringValue(
+                        str_val=get_dt_microsecond(2).strftime(
+                            dt_microsecond_format
+                        ),
+                        is_null=None,
+                    ),
                 ]
             ),
         ]
@@ -514,7 +546,11 @@ class TestLoaders:
                 'varchar_': ['a', 'b'],
                 'text_': ['a', 'b'],
                 'time_': [datetime.time(0, 11, 59), datetime.time(13)],
-                'timestamp_': [pd.Timestamp('2016'), pd.Timestamp('2017')],
+                'timestamp1_': [pd.Timestamp('2016'), pd.Timestamp('2017')],
+                'timestamp2_': [
+                    np.datetime64('2016-01-01 01:01:01.001001001'),
+                    np.datetime64('2017-01-01 01:01:01.001001001'),
+                ],
                 'date_': [
                     datetime.date(2016, 1, 1),
                     datetime.date(2017, 1, 1),
@@ -530,7 +566,8 @@ class TestLoaders:
                 'varchar_',
                 'text_',
                 'time_',
-                'timestamp_',
+                'timestamp1_',
+                'timestamp2_',
                 'date_',
             ],
         )
@@ -561,7 +598,10 @@ class TestLoaders:
                 col_name='text_', col_type=TTypeInfo(type=6, encoding=4)
             ),
             TColumnType(col_name='time_', col_type=TTypeInfo(type=7)),
-            TColumnType(col_name='timestamp_', col_type=TTypeInfo(type=8)),
+            TColumnType(col_name='timestamp1_', col_type=TTypeInfo(type=8)),
+            TColumnType(
+                col_name='timestamp2_', col_type=TTypeInfo(type=8, precision=9)
+            ),
             TColumnType(col_name='date_', col_type=TTypeInfo(type=9)),
         ]
 


### PR DESCRIPTION
# Current behavior

Currently, `pymapd` use python `datetime` object to return a date time data and, as it doesn't store nanosecond information, the result from/to pymapd missing the nanosecond information.

# Expected behavior

`pymapd` should return the nanosecond information for `timestamp(9)`.

# What does this implement/fix?

This PR adds support for datetime with nanoseconds using np.datetime64 for timestamp(9) data type.
It adds this support for `row` and `columnar` methods.

Note:

It seems that the pymapd cursor description doesn't keep some information such as precision, scale (`https://github.com/omnisci/pymapd/blob/master/pymapd/_parsers.py#L127-L145`) 

that is why I changed a test that was using `cur.description` to `con.get_table_details`


ref: https://github.com/Quansight/omnisci/issues/56#issuecomment-605326182