### PR TITLE
Update thrift bindings to match 5.3

### DIFF
--- a/omnisci/common/ttypes.py
+++ b/omnisci/common/ttypes.py
@@ -109,6 +109,7 @@ class TEncodingType(object):
     SPARSE = 5
     GEOINT = 6
     DATE_IN_DAYS = 7
+    PACKED_PIXEL_COORD = 8
 
     _VALUES_TO_NAMES = {
         0: "NONE",
@@ -119,6 +120,7 @@ class TEncodingType(object):
         5: "SPARSE",
         6: "GEOINT",
         7: "DATE_IN_DAYS",
+        8: "PACKED_PIXEL_COORD",
     }
 
     _NAMES_TO_VALUES = {
@@ -130,6 +132,7 @@ class TEncodingType(object):
         "SPARSE": 5,
         "GEOINT": 6,
         "DATE_IN_DAYS": 7,
+        "PACKED_PIXEL_COORD": 8,
     }
 
 

--- a/omnisci/thrift/OmniSci-remote
+++ b/omnisci/thrift/OmniSci-remote
@@ -57,7 +57,7 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
     print('  TDataFrame sql_execute_gdf(TSessionId session, string query, i32 device_id, i32 first_n)')
     print('  void deallocate_df(TSessionId session, TDataFrame df, TDeviceType device_type, i32 device_id)')
     print('  void interrupt(TSessionId query_session, TSessionId interrupt_session)')
-    print('  TTableDescriptor sql_validate(TSessionId session, string query)')
+    print('  TRowDescriptor sql_validate(TSessionId session, string query)')
     print('   get_completion_hints(TSessionId session, string sql, i32 cursor)')
     print('  void set_execution_mode(TSessionId session, TExecuteMode mode)')
     print('  TRenderResult render_vega(TSessionId session, i64 widget_id, string vega_json, i32 compression_level, string nonce)')
@@ -84,8 +84,9 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
     print('  string get_first_geo_file_in_archive(TSessionId session, string archive_path, TCopyParams copy_params)')
     print('   get_all_files_in_archive(TSessionId session, string archive_path, TCopyParams copy_params)')
     print('   get_layers_in_geo_file(TSessionId session, string file_name, TCopyParams copy_params)')
+    print('  i64 query_get_outer_fragment_count(TSessionId session, string query)')
     print('  TTableMeta check_table_consistency(TSessionId session, i32 table_id)')
-    print('  TPendingQuery start_query(TSessionId leaf_session, TSessionId parent_session, string query_ra, bool just_explain)')
+    print('  TPendingQuery start_query(TSessionId leaf_session, TSessionId parent_session, string query_ra, bool just_explain,  outer_fragment_indices)')
     print('  TStepResult execute_query_step(TPendingQuery pending_query)')
     print('  void broadcast_serialized_rows(TSerializedRows serialized_rows, TRowDescriptor row_desc, TQueryId query_id)')
     print('  TPendingRenderQuery start_render_query(TSessionId session, i64 widget_id, i16 node_idx, string vega_json)')
@@ -541,6 +542,12 @@ elif cmd == 'get_layers_in_geo_file':
         sys.exit(1)
     pp.pprint(client.get_layers_in_geo_file(eval(args[0]), args[1], eval(args[2]),))
 
+elif cmd == 'query_get_outer_fragment_count':
+    if len(args) != 2:
+        print('query_get_outer_fragment_count requires 2 args')
+        sys.exit(1)
+    pp.pprint(client.query_get_outer_fragment_count(eval(args[0]), args[1],))
+
 elif cmd == 'check_table_consistency':
     if len(args) != 2:
         print('check_table_consistency requires 2 args')
@@ -548,10 +555,10 @@ elif cmd == 'check_table_consistency':
     pp.pprint(client.check_table_consistency(eval(args[0]), eval(args[1]),))
 
 elif cmd == 'start_query':
-    if len(args) != 4:
-        print('start_query requires 4 args')
+    if len(args) != 5:
+        print('start_query requires 5 args')
         sys.exit(1)
-    pp.pprint(client.start_query(eval(args[0]), eval(args[1]), args[2], eval(args[3]),))
+    pp.pprint(client.start_query(eval(args[0]), eval(args[1]), args[2], eval(args[3]), eval(args[4]),))
 
 elif cmd == 'execute_query_step':
     if len(args) != 1:

--- a/omnisci/thrift/ttypes.py
+++ b/omnisci/thrift/ttypes.py
@@ -149,6 +149,30 @@ class TMergeType(object):
     }
 
 
+class TQueryType(object):
+    UNKNOWN = 0
+    READ = 1
+    WRITE = 2
+    SCHEMA_READ = 3
+    SCHEMA_WRITE = 4
+
+    _VALUES_TO_NAMES = {
+        0: "UNKNOWN",
+        1: "READ",
+        2: "WRITE",
+        3: "SCHEMA_READ",
+        4: "SCHEMA_WRITE",
+    }
+
+    _NAMES_TO_VALUES = {
+        "UNKNOWN": 0,
+        "READ": 1,
+        "WRITE": 2,
+        "SCHEMA_READ": 3,
+        "SCHEMA_WRITE": 4,
+    }
+
+
 class TExpressionRangeType(object):
     INVALID = 0
     INTEGER = 1
@@ -704,8 +728,7 @@ class TColumnData(object):
                 oprot.writeI64(iter38)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
-        # for array data, when a None data is given, self.real_col is 0
-        if self.real_col is not None and not isinstance(self.real_col, int):
+        if self.real_col is not None:
             oprot.writeFieldBegin('real_col', TType.LIST, 2)
             oprot.writeListBegin(TType.DOUBLE, len(self.real_col))
             for iter39 in self.real_col:
@@ -1203,17 +1226,19 @@ class TQueryResult(object):
      - nonce
      - debug
      - success
+     - query_type
 
     """
 
 
-    def __init__(self, row_set=None, execution_time_ms=None, total_time_ms=None, nonce=None, debug=None, success=True,):
+    def __init__(self, row_set=None, execution_time_ms=None, total_time_ms=None, nonce=None, debug=None, success=True, query_type=0,):
         self.row_set = row_set
         self.execution_time_ms = execution_time_ms
         self.total_time_ms = total_time_ms
         self.nonce = nonce
         self.debug = debug
         self.success = success
+        self.query_type = query_type
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -1255,6 +1280,11 @@ class TQueryResult(object):
                     self.success = iprot.readBool()
                 else:
                     iprot.skip(ftype)
+            elif fid == 7:
+                if ftype == TType.I32:
+                    self.query_type = iprot.readI32()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -1288,6 +1318,10 @@ class TQueryResult(object):
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.BOOL, 6)
             oprot.writeBool(self.success)
+            oprot.writeFieldEnd()
+        if self.query_type is not None:
+            oprot.writeFieldBegin('query_type', TType.I32, 7)
+            oprot.writeI32(self.query_type)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -5933,6 +5967,7 @@ TQueryResult.thrift_spec = (
     (4, TType.STRING, 'nonce', 'UTF8', None, ),  # 4
     (5, TType.STRING, 'debug', 'UTF8', None, ),  # 5
     (6, TType.BOOL, 'success', None, True, ),  # 6
+    (7, TType.I32, 'query_type', None, 0, ),  # 7
 )
 all_structs.append(TDataFrame)
 TDataFrame.thrift_spec = (

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -534,6 +534,97 @@ class TestOptionalImports:
 
 
 class TestExtras:
+    def test_sql_validate(self, con):
+        from omnisci.common.ttypes import TTypeInfo
+
+        c = con.cursor()
+        c.execute('drop table if exists stocks;')
+        create = (
+            'create table stocks (date_ text, trans text, symbol text, '
+            'qty int, price float, vol float);'
+        )
+        c.execute(create)
+
+        q = "select * from stocks"
+        results = con._client.sql_validate(con._session, q)
+        col_names = sorted([r.col_name for r in results])
+        col_types = [r.col_type for r in results]
+
+        expected_col_names = [
+            'date_',
+            'price',
+            'qty',
+            'symbol',
+            'trans',
+            'vol',
+        ]
+
+        expected_types = [
+            TTypeInfo(
+                type=6,
+                encoding=4,
+                nullable=True,
+                is_array=False,
+                precision=0,
+                scale=0,
+                comp_param=32,
+                size=-1,
+            ),
+            TTypeInfo(
+                type=6,
+                encoding=4,
+                nullable=True,
+                is_array=False,
+                precision=0,
+                scale=0,
+                comp_param=32,
+                size=-1,
+            ),
+            TTypeInfo(
+                type=6,
+                encoding=4,
+                nullable=True,
+                is_array=False,
+                precision=0,
+                scale=0,
+                comp_param=32,
+                size=-1,
+            ),
+            TTypeInfo(
+                type=1,
+                encoding=0,
+                nullable=True,
+                is_array=False,
+                precision=0,
+                scale=0,
+                comp_param=0,
+                size=-1,
+            ),
+            TTypeInfo(
+                type=3,
+                encoding=0,
+                nullable=True,
+                is_array=False,
+                precision=0,
+                scale=0,
+                comp_param=0,
+                size=-1,
+            ),
+            TTypeInfo(
+                type=3,
+                encoding=0,
+                nullable=True,
+                is_array=False,
+                precision=0,
+                scale=0,
+                comp_param=0,
+                size=-1,
+            ),
+        ]
+
+        assert col_types == expected_types
+        assert col_names == expected_col_names
+
     def test_get_tables(self, con):
 
         c = con.cursor()


### PR DESCRIPTION
Primarily, the return type for `sql_validate` was changed from `TTableDescriptor` to  `TRowDescriptor` in OmniSciDB. This affects use of sql execute from the IBIS client as it performs a sql validate step prior to execution.