### PR TITLE
Remove geopandas as a run dependency

### DIFF
--- a/ci/install-test-deps-conda.sh
+++ b/ci/install-test-deps-conda.sh
@@ -20,9 +20,8 @@ conda create -n omnisci-dev python=${PYTHON} \
 'pyarrow==0.15.0' \
 'pandas>=0.25,<0.26' \
 libtiff=4.0.10 \
-geopandas \
-shapely \
 sqlalchemy \
+geopandas \
 numpy \
 numpydoc \
 coverage \

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -2,7 +2,6 @@ thrift==0.13.0
 pyarrow==0.15.0
 pandas>=0.25,<0.26
 geopandas
-shapely
 sqlalchemy
 numpy
 numpydoc

--- a/environment.yml
+++ b/environment.yml
@@ -5,13 +5,11 @@ channels:
 dependencies:
 - thrift=0.13.0
 - arrow-cpp=0.15.0
-- geopandas
 # related: https://github.com/conda-forge/pillow-feedstock/issues/73
 - libtiff=4.0.10
 - pyarrow==0.15.0
 - pandas>=0.25,<0.26
 - python>=3.6,<3.8
-- shapely
 - sqlalchemy
 - numpy
 - numpydoc

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
 - arrow-cpp=0.15.0
 # related: https://github.com/conda-forge/pillow-feedstock/issues/73
 - libtiff=4.0.10
+- geopandas
 - pyarrow==0.15.0
 - pandas>=0.25,<0.26
 - python>=3.6,<3.8

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -9,7 +9,6 @@ dependencies:
 - cudf=0.13
 - cudatoolkit=10.1
 - arrow-cpp=0.15.0
-- geopandas
 # related: https://github.com/conda-forge/pillow-feedstock/issues/73
 - libtiff=4.0.10
 - pyarrow==0.15.0
@@ -24,7 +23,6 @@ dependencies:
 - pre-commit
 - pytest-cov
 - pytest-mock
-- shapely
 - sphinx
 - requests
 - sphinx_rtd_theme

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -11,6 +11,7 @@ dependencies:
 - arrow-cpp=0.15.0
 # related: https://github.com/conda-forge/pillow-feedstock/issues/73
 - libtiff=4.0.10
+- geopandas
 - pyarrow==0.15.0
 - pandas>=0.25,<0.26
 - python>=3.6,<3.8

--- a/pymapd/_pandas_loaders.py
+++ b/pymapd/_pandas_loaders.py
@@ -1,7 +1,6 @@
 import datetime
 import math
 
-import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pyarrow as pa
@@ -26,6 +25,11 @@ from ._utils import (
     mapd_to_na,
     mapd_to_slot,
 )
+
+try:
+    import geopandas as gpd
+except ImportError:
+    gpd = None
 
 
 GEO_TYPE_NAMES = ['POINT', 'LINESTRING', 'POLYGON', 'MULTIPOLYGON']
@@ -257,13 +261,16 @@ def _serialize_arrow_payload(data, table_metadata, preserve_index=True):
 
 def build_row_desc(data, preserve_index=False):
 
-    if not isinstance(data, (pd.DataFrame, gpd.GeoDataFrame)):
+    if not (
+        isinstance(data, pd.DataFrame)
+        or (gpd is not None and isinstance(data, gpd.GeoDataFrame))
+    ):
         # Once https://issues.apache.org/jira/browse/ARROW-1576 is complete
         # we can support pa.Table here too
         raise TypeError(
             "Create table is not supported for type {}. "
-            "Use a pandas DataFrame, or perform the create "
-            "separately".format(type(data))
+            "Use a pandas DataFrame or a GeoPandas DataFrame, "
+            "or perform the create separately".format(type(data))
         )
 
     if preserve_index:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 install_requires = [
     'pyarrow == 0.15.0',
     'thrift == 0.13.0',
-    'geopandas',
     'shapely',
     'sqlalchemy >= 1.3',
     'pandas >= 0.25,<0.26',
@@ -24,7 +23,7 @@ install_requires = [
 
 # Optional Requirements
 doc_requires = ['sphinx', 'numpydoc', 'sphinx-rtd-theme']
-test_requires = ['coverage', 'pytest', 'pytest-mock']
+test_requires = ['coverage', 'pytest', 'pytest-mock', 'geopandas']
 dev_requires = doc_requires + test_requires + ['pre-commit']
 complete_requires = dev_requires
 


### PR DESCRIPTION
This PR resolves #330

as it looks like geopandas dependency increased the conda resolving time considerably, this PR removes geopandas from run dependency. 