### PR TITLE
Fix timestamp precision bug

### DIFF
--- a/pymapd/_pandas_loaders.py
+++ b/pymapd/_pandas_loaders.py
@@ -107,11 +107,11 @@ def get_mapd_type_from_object(data):
         raise TypeError("Unhandled type {}".format(data.dtype))
 
 
-def thrift_cast(data, mapd_type, scale=0):
+def thrift_cast(data, mapd_type, scale=0, precision=0):
     """Cast data type to the expected thrift types"""
 
     if mapd_type == 'TIMESTAMP':
-        return datetime_to_seconds(data)
+        return datetime_to_seconds(data, precision)
     elif mapd_type == 'TIME':
         return pd.Series(time_to_seconds(x) for x in data)
     elif mapd_type == 'DATE':
@@ -156,6 +156,7 @@ def build_input_columnar(
             mapd_type = col_types[colindex].type
             is_array = col_types[colindex].is_array
             scale = col_types[colindex].scale
+            precision = col_types[colindex].precision
             has_nulls = data[col].hasnans
 
             if has_nulls:
@@ -172,7 +173,7 @@ def build_input_columnar(
                 # requires a cast to integer
                 for c in data:
                     data.loc[:, c] = thrift_cast(
-                        data=data[c], mapd_type=mapd_type
+                        data=data[c], mapd_type=mapd_type, precision=precision
                     )
 
             if mapd_type in ['DECIMAL']:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -815,6 +815,44 @@ class TestLoaders:
             ),
             pytest.param(
                 pd.DataFrame(
+                    {
+                        "a": [
+                            datetime.datetime.fromtimestamp(
+                                float(1600443582510) / 1e3
+                            ),
+                            datetime.datetime.fromtimestamp(
+                                float(1600443582510) / 1e3
+                            ),
+                            datetime.datetime.fromtimestamp(
+                                float(1600443582510) / 1e3
+                            ),
+                        ],
+                    },
+                ),
+                'a TIMESTAMP(3)',
+                id='scalar_datetime_ms',
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {
+                        "a": [
+                            datetime.datetime.fromtimestamp(
+                                float(1600443582510) / 1e6
+                            ),
+                            datetime.datetime.fromtimestamp(
+                                float(1600443582510) / 1e6
+                            ),
+                            datetime.datetime.fromtimestamp(
+                                float(1600443582510) / 1e6
+                            ),
+                        ],
+                    },
+                ),
+                'a TIMESTAMP(6)',
+                id='scalar_datetime_us',
+            ),
+            pytest.param(
+                pd.DataFrame(
                     [
                         {'ary': [2, 3, 4]},
                         {'ary': [4444]},

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -228,8 +228,18 @@ class TestLoaders:
                     {'name': 'a', 'type': 'INT', 'is_array': True},
                     {'name': 'b', 'type': 'DOUBLE', 'is_array': True},
                     {'name': 'c', 'type': 'INT', 'is_array': False},
-                    {'name': 'd', 'type': 'TIMESTAMP', 'is_array': False},
-                    {'name': 'e', 'type': 'TIMESTAMP', 'is_array': False},
+                    {
+                        'name': 'd',
+                        'type': 'TIMESTAMP',
+                        'is_array': False,
+                        'precision': 9,
+                    },
+                    {
+                        'name': 'e',
+                        'type': 'TIMESTAMP',
+                        'is_array': False,
+                        'precision': 0,
+                    },
                     {
                         'name': 'f',
                         'type': 'DECIMAL',
@@ -389,7 +399,14 @@ class TestLoaders:
             ColumnDetails(name='text_', type='STR', **common_col_params),
             ColumnDetails(name='time_', type='TIME', **common_col_params),
             ColumnDetails(
-                name='timestamp_', type='TIMESTAMP', **common_col_params
+                name='timestamp_',
+                type='TIMESTAMP',
+                nullable=True,
+                precision=0,
+                scale=0,
+                comp_param=0,
+                encoding='NONE',
+                is_array=False,
             ),
             ColumnDetails(name='date_', type='DATE', **common_col_params),
         ]
@@ -457,7 +474,6 @@ class TestLoaders:
     def test_build_table_columnar_nulls(self):
         common_col_params = dict(
             nullable=True,
-            precision=0,
             scale=0,
             comp_param=0,
             encoding='NONE',
@@ -465,17 +481,36 @@ class TestLoaders:
         )
 
         col_types = [
-            ColumnDetails(name='boolean_', type='BOOL', **common_col_params),
-            ColumnDetails(name='int_', type='INT', **common_col_params),
-            ColumnDetails(name='bigint_', type='BIGINT', **common_col_params),
-            ColumnDetails(name='double_', type='DOUBLE', **common_col_params),
-            ColumnDetails(name='varchar_', type='STR', **common_col_params),
-            ColumnDetails(name='text_', type='STR', **common_col_params),
-            ColumnDetails(name='time_', type='TIME', **common_col_params),
             ColumnDetails(
-                name='timestamp_', type='TIMESTAMP', **common_col_params
+                name='boolean_', type='BOOL', precision=0, **common_col_params
             ),
-            ColumnDetails(name='date_', type='DATE', **common_col_params),
+            ColumnDetails(
+                name='int_', type='INT', precision=0, **common_col_params
+            ),
+            ColumnDetails(
+                name='bigint_', type='BIGINT', precision=0, **common_col_params
+            ),
+            ColumnDetails(
+                name='double_', type='DOUBLE', precision=0, **common_col_params
+            ),
+            ColumnDetails(
+                name='varchar_', type='STR', precision=0, **common_col_params
+            ),
+            ColumnDetails(
+                name='text_', type='STR', precision=0, **common_col_params
+            ),
+            ColumnDetails(
+                name='time_', type='TIME', precision=0, **common_col_params
+            ),
+            ColumnDetails(
+                name='timestamp_',
+                type='TIMESTAMP',
+                **common_col_params,
+                precision=0,
+            ),
+            ColumnDetails(
+                name='date_', type='DATE', precision=0, **common_col_params
+            ),
         ]
 
         data = pd.DataFrame(


### PR DESCRIPTION
Timestamp types with millisecond precision (`TIMESTAMP(3)`) were not converted correctly when casting from the thrift type to their respective Python type.

I have addressed this by properly accounting for precision when converting from datetime to seconds. Previously we were only estimating the precision by checking to see if nanoseconds in the datetime were > 0. Instead, precision is now passed in which allows us to determine the precision based on the column type info.

cc: @xmnlab 