### PR TITLE
Relax version constraints for pyarrow and pandas

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,8 @@ pymapd
 A python `DB API`_ compliant interface for `OmniSci`_ (formerly MapD). See the
 `documentation`_ for more.
 
-Quick Install
--------------
+Quick Install (CPU)
+-------------------
 
 Packages are available on conda-forge and PyPI::
 
@@ -22,11 +22,16 @@ Packages are available on conda-forge and PyPI::
 
    pip install pymapd
 
-To install cudf for GPU Dataframe support (conda-only)::
+Quick Install (GPU)
+-------------------
 
-   conda install -c nvidia/label/cuda10.0 -c rapidsai/label/cuda10.0 -c numba -c conda-forge -c defaults cudf pymapd
+We recommend creating a fresh conda 3.7 or 3.8 environment when installing
+pymapd with GPU capabilities.
 
+To install pymapd and cudf for GPU Dataframe support (conda-only)::
 
+   conda create -n omnisci-gpu -c rapidsai -c nvidia -c conda-forge \
+    -c defaults cudf=0.15 python=3.7 cudatoolkit=10.2 pymapd
 
 .. _DB API: https://www.python.org/dev/peps/pep-0249/
 .. _OmniSci: https://www.omnisci.com/

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
 - defaults
 dependencies:
 - thrift=0.13.0
-- pyarrow==0.17.1.*
-- pandas==1.1.*
+- pyarrow
+- pandas
 - python>3.6.6,<3.9
 # related: https://github.com/conda-forge/pillow-feedstock/issues/73
 - libtiff=4.0.10

--- a/environment_gpu.yml
+++ b/environment_gpu.yml
@@ -8,8 +8,8 @@ dependencies:
 - thrift=0.13.0
 - cudf=0.15
 - cudatoolkit=11.0
-- pyarrow==0.17.1.*
-- pandas==1.1.*
+- pyarrow
+- pandas
 - python>3.6.6,<3.9
 # related: https://github.com/conda-forge/pillow-feedstock/issues/73
 - libtiff=4.0.10

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 install_requires = [
-    'pyarrow >= 0.17,<0.18',
+    'pyarrow',
     'thrift == 0.13.0',
     'shapely',
     'sqlalchemy >= 1.3',
-    'pandas >= 0.25,<0.26',
+    'pandas',
     'packaging >= 20.0',
     'requests >= 2.23.0',
     'numba >= 0.48',


### PR DESCRIPTION
The primary reason we had these pinned was to guarantee that a later install of `cudf` would resolve correctly (as we aim to match the pins of `cudf`). Instead, we switch to special-case the `cudf` install and update the documentation to recommend creating a new environment, installing both `cudf` and `pymapd` at the same time to ensure we can resolve deps properly.